### PR TITLE
Switch argument parser Switch CLI argument parser to clipp 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jamolnng/argparse@6a44959 -X header
+muellan/clipp@v1.2.3 -X header
 peelonet/peelo-prompt@v0.3.1
 peelonet/peelo-result@5f09c27 -X header
 peelonet/peelo-unicode@v0.2.0

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -111,7 +111,7 @@ namespace snek::lexer
             ++current;
           }
           ++position.line;
-          position.column = 0;
+          position.column = 1;
 
           return '\n';
         }


### PR DESCRIPTION
I'm kinda frustrated how current CLI argument parser library does not
support command line arguments such as `--allow-something` and found an
library called clipp that seems to handle them, so lets switch to that.