### PR TITLE
Refactor our "message passing"

### DIFF
--- a/include/snek/message.hpp
+++ b/include/snek/message.hpp
@@ -25,82 +25,108 @@
  */
 #pragma once
 
-#include <unordered_map>
 #include <vector>
 
-#include <peelo/result.hpp>
-
-#include <snek/error.hpp>
 #include <snek/value/base.hpp>
 
 namespace snek
 {
-  class Interpreter;
-  class Parameter;
-
-  namespace ast { struct Position; }
-
   class Message
   {
   public:
-    using key_type = std::u32string;
-    using mapped_type = value::Ptr;
-    using container_type = std::unordered_map<key_type, mapped_type>;
-    using value_type = container_type::value_type;
+    using value_type = std::shared_ptr<value::Base>;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using container_type = std::vector<value_type>;
+    using size_type = container_type::size_type;
     using iterator = container_type::iterator;
     using const_iterator = container_type::const_iterator;
-    using result_type = peelo::result<Message, Error>;
+    using reverse_iterator = container_type::reverse_iterator;
+    using const_reverse_iterator = container_type::const_reverse_iterator;
 
-    Message(const container_type& arguments = container_type());
+    Message(const container_type& args = container_type());
     Message(const Message& that);
     Message(Message&& that);
     Message& operator=(const Message& that);
     Message& operator=(Message&& that);
 
-    static result_type create(
-      const std::vector<Parameter>& parameters,
-      const std::vector<value::Ptr>& arguments,
-      const Interpreter& interpreter,
-      const std::optional<ast::Position>& position = std::nullopt
-    );
-
-    inline container_type& arguments()
+    inline container_type args()
     {
-      return m_arguments;
+      return m_args;
     }
 
-    inline const container_type& arguments() const
+    inline const container_type args() const
     {
-      return m_arguments;
+      return m_args;
     }
 
-    template<class T>
-    inline std::shared_ptr<T> get(const std::u32string& name) const
+    template<class T = value::Base>
+    inline std::shared_ptr<T> at(size_type index) const
     {
-      return std::static_pointer_cast<T>(m_arguments.find(name)->second);
+      return std::static_pointer_cast<T>(m_args[index]);
     }
 
     inline iterator begin()
     {
-      return std::begin(m_arguments);
+      return std::begin(m_args);
     }
 
     inline const_iterator begin() const
     {
-      return std::begin(m_arguments);
+      return std::begin(m_args);
+    }
+
+    inline const_iterator cbegin() const
+    {
+      return std::cbegin(m_args);
     }
 
     inline iterator end()
     {
-      return std::end(m_arguments);
+      return std::end(m_args);
     }
 
     inline const_iterator end() const
     {
-      return std::end(m_arguments);
+      return std::end(m_args);
+    }
+
+    inline const_iterator cend() const
+    {
+      return std::cend(m_args);
+    }
+
+    inline reverse_iterator rbegin()
+    {
+      return std::rbegin(m_args);
+    }
+
+    inline const_reverse_iterator rbegin() const
+    {
+      return std::rbegin(m_args);
+    }
+
+    inline const_reverse_iterator crbegin() const
+    {
+      return std::crbegin(m_args);
+    }
+
+    inline reverse_iterator rend()
+    {
+      return std::rend(m_args);
+    }
+
+    inline const_reverse_iterator rend() const
+    {
+      return std::rend(m_args);
+    }
+
+    inline const_reverse_iterator crend() const
+    {
+      return std::crend(m_args);
     }
 
   private:
-    container_type m_arguments;
+    container_type m_args;
   };
 }

--- a/include/snek/value/func.hpp
+++ b/include/snek/value/func.hpp
@@ -32,15 +32,14 @@
 #include <peelo/result.hpp>
 
 #include <snek/error.hpp>
+#include <snek/message.hpp>
 #include <snek/parameter.hpp>
 #include <snek/scope.hpp>
 #include <snek/type/base.hpp>
-#include <snek/value/base.hpp>
 
 namespace snek
 {
   class Interpreter;
-  class Message;
 }
 
 namespace snek::ast::stmt
@@ -95,11 +94,20 @@ namespace snek::value
       return m_enclosing_scope;
     }
 
-    result_type call(
+    result_type send(
       Interpreter& interpreter,
-      const std::vector<Ptr>& arguments,
+      const Message& message,
       const std::optional<ast::Position>& position = std::nullopt
     ) const;
+
+    inline result_type send(
+      Interpreter& interpreter,
+      const Message::container_type& args,
+      const std::optional<ast::Position>& position = std::nullopt
+    ) const
+    {
+      return send(interpreter, Message(args), position);
+    }
 
     std::shared_ptr<type::Base> type(const Interpreter& interpreter) const;
 

--- a/src/api/debug.cpp
+++ b/src/api/debug.cpp
@@ -43,9 +43,7 @@ namespace snek::api::debug
   static result_type
   func_toString(Interpreter& interpreter, const Message& message)
   {
-    return result_type::ok(make_str(
-      message.get<value::Base>(U"input")->to_string()
-    ));
+    return result_type::ok(make_str(message.at(0)->to_string()));
   }
 
   Scope

--- a/src/api/io.cpp
+++ b/src/api/io.cpp
@@ -36,7 +36,7 @@ namespace snek::api::io
   func_print(Interpreter& interpreter, const Message& message)
   {
     using peelo::unicode::encoding::utf8::encode;
-    const auto input = message.get<value::Str>(U"input");
+    const auto input = message.at<value::Str>(0);
 
     std::cout << encode(input->value()) << std::endl;
 

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -42,7 +42,7 @@ namespace snek::api::list
   static result_type
   func_isEmpty(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
+    const auto& input = message.at<value::List>(0);
 
     return result_type::ok(interpreter.bool_value(input->elements().empty()));
   }
@@ -55,7 +55,7 @@ namespace snek::api::list
   static result_type
   func_length(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
+    const auto& input = message.at<value::List>(0);
 
     return result_type::ok(make_int(input->elements().size()));
   }
@@ -68,7 +68,7 @@ namespace snek::api::list
   static result_type
   func_reverse(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
+    const auto& input = message.at<value::List>(0);
 
     return result_type::ok(make_list(input->rbegin(), input->rend()));
   }
@@ -82,8 +82,8 @@ namespace snek::api::list
   static result_type
   func_includes(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
-    const auto& searched_element = message.get<value::Base>(U"element");
+    const auto& input = message.at<value::List>(0);
+    const auto& searched_element = message.at<value::Base>(1);
 
     for (const auto& element : *input)
     {
@@ -105,12 +105,12 @@ namespace snek::api::list
   static result_type
   func_forEach(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
-    const auto& func = message.get<value::Func>(U"func");
+    const auto& input = message.at<value::List>(0);
+    const auto& func = message.at<value::Func>(1);
 
     for (const auto& element : *input)
     {
-      const auto result = func->call(interpreter, { element });
+      const auto result = func->send(interpreter, { element });
 
       if (!result)
       {
@@ -130,13 +130,13 @@ namespace snek::api::list
   static result_type
   func_filter(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
-    const auto& func = message.get<value::Func>(U"func");
+    const auto& input = message.at<value::List>(0);
+    const auto& func = message.at<value::Func>(1);
     value::List::container_type output;
 
     for (const auto& element : *input)
     {
-      const auto result = func->call(interpreter, { element });
+      const auto result = func->send(interpreter, { element });
 
       if (!result)
       {
@@ -169,13 +169,13 @@ namespace snek::api::list
   static result_type
   func_map(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::List>(U"input");
-    const auto& func = message.get<value::Func>(U"func");
+    const auto& input = message.at<value::List>(0);
+    const auto& func = message.at<value::Func>(1);
     value::List::container_type output;
 
     for (const auto& element : *input)
     {
-      const auto result = func->call(interpreter, { element });
+      const auto result = func->send(interpreter, { element });
 
       if (!result)
       {

--- a/src/api/str.cpp
+++ b/src/api/str.cpp
@@ -45,7 +45,7 @@ namespace snek::api::str
   static result_type
   func_isEmpty(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& input = message.at<value::Str>(0);
 
     return result_type::ok(interpreter.bool_value(input->value().empty()));
   }
@@ -58,7 +58,7 @@ namespace snek::api::str
   static result_type
   func_length(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& input = message.at<value::Str>(0);
 
     return result_type::ok(make_int(input->value().length()));
   }
@@ -71,7 +71,7 @@ namespace snek::api::str
   static result_type
   func_reverse(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& input = message.at<value::Str>(0);
 
     return result_type::ok(make_str(input->rbegin(), input->rend()));
   }
@@ -84,8 +84,8 @@ namespace snek::api::str
   static result_type
   func_repeat(Interpreter& interpreter, const Message& message)
   {
-    const auto& times = message.get<value::Int>(U"times");
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& times = message.at<value::Int>(0);
+    const auto& input = message.at<value::Str>(1);
     std::u32string result;
 
     result.reserve(times->value());
@@ -105,7 +105,7 @@ namespace snek::api::str
   static result_type
   func_concat(Interpreter& interpreter, const Message& message)
   {
-    const auto& list = message.get<value::List>(U"list");
+    const auto& list = message.at<value::List>(0);
     std::u32string result;
 
     for (const auto& element : *list)
@@ -124,7 +124,7 @@ namespace snek::api::str
   static result_type
   func_toUpper(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& input = message.at<value::Str>(0);
     std::u32string result;
 
     result.reserve(input->value().length());
@@ -144,7 +144,7 @@ namespace snek::api::str
   static result_type
   func_toLower(Interpreter& interpreter, const Message& message)
   {
-    const auto& input = message.get<value::Str>(U"input");
+    const auto& input = message.at<value::Str>(0);
     std::u32string result;
 
     result.reserve(input->value().length());

--- a/src/ast/expr/call.cpp
+++ b/src/ast/expr/call.cpp
@@ -41,7 +41,7 @@ namespace snek::ast::expr
   Call::eval(Interpreter& interpreter, const Scope& scope) const
   {
     const auto callee = m_callee->eval(interpreter, scope);
-    std::vector<value::Ptr> arguments;
+    Message::container_type arguments;
 
     if (!callee)
     {
@@ -67,7 +67,7 @@ namespace snek::ast::expr
       arguments.push_back(result.value());
     }
 
-    return std::static_pointer_cast<value::Func>(callee.value())->call(
+    return std::static_pointer_cast<value::Func>(callee.value())->send(
       interpreter,
       arguments,
       position()

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -24,24 +24,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <snek/message.hpp>
-#include <snek/parameter.hpp>
-#include <snek/type/base.hpp>
 
 namespace snek
 {
-  Message::Message(const container_type& arguments)
-    : m_arguments(arguments) {}
+  Message::Message(const container_type& args)
+    : m_args(args) {}
 
   Message::Message(const Message& that)
-    : m_arguments(that.m_arguments) {}
+    : m_args(that.m_args) {}
 
   Message::Message(Message&& that)
-    : m_arguments(std::move(that.m_arguments)) {}
+    : m_args(std::move(that.m_args)) {}
 
   Message&
   Message::operator=(const Message& that)
   {
-    m_arguments = that.m_arguments;
+    m_args = that.m_args;
 
     return *this;
   }
@@ -49,46 +47,8 @@ namespace snek
   Message&
   Message::operator=(Message&& that)
   {
-    m_arguments = std::move(that.m_arguments);
+    m_args = std::move(that.m_args);
 
     return *this;
-  }
-
-  Message::result_type
-  Message::create(
-    const std::vector<Parameter>& parameters,
-    const std::vector<value::Ptr>& arguments,
-    const Interpreter& interpreter,
-    const std::optional<ast::Position>& position
-  )
-  {
-    container_type container;
-
-    if (parameters.size() > arguments.size())
-    {
-      return result_type::error({
-        position,
-        U"Not enough arguments."
-      });
-    }
-    for (std::size_t i = 0; i < parameters.size(); ++i)
-    {
-      const auto& parameter = parameters[i];
-      const auto& argument = arguments[i];
-
-      if (!parameter.type()->matches(argument))
-      {
-        return result_type::error({
-          position,
-          argument->type(interpreter)->to_string() +
-          U" cannot be assigned to " +
-          parameter.type()->to_string() +
-          U"."
-        });
-      }
-      container[parameter.name()] = argument;
-    }
-
-    return result_type::ok(Message(container));
   }
 }


### PR DESCRIPTION
Switch to index based arguments instead of name based. Hopefully the
performance is better. Also change the way message class is used, so
that it's passed to functions instead of being constructed during
function invocation. It could be in the future also used to store side
effects of function invocation, such as fatal errors.