### PR TITLE
Add AST node to string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ ADD_LIBRARY(
   src/type/str.cpp
   src/type/tuple.cpp
   src/type/union.cpp
+  src/utils.cpp
   src/value/base.cpp
   src/value/bool.cpp
   src/value/float.cpp

--- a/include/snek/ast/expr/binary.hpp
+++ b/include/snek/ast/expr/binary.hpp
@@ -69,6 +69,8 @@ namespace snek::ast::expr
       return m_right_expression;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/bool.hpp
+++ b/include/snek/ast/expr/bool.hpp
@@ -41,6 +41,11 @@ namespace snek::ast::expr
       return m_value;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_value ? U"true" : U"false";
+    }
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/call.hpp
+++ b/include/snek/ast/expr/call.hpp
@@ -50,6 +50,8 @@ namespace snek::ast::expr
       return m_arguments;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/field.hpp
+++ b/include/snek/ast/expr/field.hpp
@@ -48,6 +48,11 @@ namespace snek::ast::expr
       return m_field;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_record_expression->to_string() + U'.' + m_field;
+    }
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/float.hpp
+++ b/include/snek/ast/expr/float.hpp
@@ -41,6 +41,8 @@ namespace snek::ast::expr
       return m_value;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/func.hpp
+++ b/include/snek/ast/expr/func.hpp
@@ -62,6 +62,8 @@ namespace snek::ast::expr
       return m_return_type;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/id.hpp
+++ b/include/snek/ast/expr/id.hpp
@@ -39,6 +39,11 @@ namespace snek::ast::expr
       return m_name;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_name;
+    }
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
     assign_result_type assign(

--- a/include/snek/ast/expr/int.hpp
+++ b/include/snek/ast/expr/int.hpp
@@ -43,6 +43,8 @@ namespace snek::ast::expr
       return m_value;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/list.hpp
+++ b/include/snek/ast/expr/list.hpp
@@ -46,6 +46,8 @@ namespace snek::ast::expr
       return m_elements;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
     assign_result_type assign(

--- a/include/snek/ast/expr/not.hpp
+++ b/include/snek/ast/expr/not.hpp
@@ -42,6 +42,11 @@ namespace snek::ast::expr
       return m_expression;
     }
 
+    inline std::u32string to_string() const
+    {
+      return U'!' + m_expression->to_string();
+    }
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/expr/null.hpp
+++ b/include/snek/ast/expr/null.hpp
@@ -34,6 +34,11 @@ namespace snek::ast::expr
   public:
     explicit Null(const Position& position);
 
+    inline std::u32string to_string() const
+    {
+      return U"null";
+    }
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
   };
 }

--- a/include/snek/ast/expr/record.hpp
+++ b/include/snek/ast/expr/record.hpp
@@ -41,6 +41,8 @@ namespace snek::ast::expr
 
     explicit Record(const Position& position, const container_type& fields);
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
     assign_result_type assign(

--- a/include/snek/ast/expr/str.hpp
+++ b/include/snek/ast/expr/str.hpp
@@ -43,6 +43,8 @@ namespace snek::ast::expr
       return m_value;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/import.hpp
+++ b/include/snek/ast/import.hpp
@@ -65,6 +65,8 @@ namespace snek::ast::import
       return m_alias;
     }
 
+    std::u32string to_string() const;
+
     result_type import(
       const Scope& module,
       const std::u32string& module_path,
@@ -87,6 +89,11 @@ namespace snek::ast::import
     inline const std::u32string name() const
     {
       return m_name;
+    }
+
+    inline std::u32string to_string() const
+    {
+      return U"* as " + m_name;
     }
 
     result_type import(

--- a/include/snek/ast/parameter.hpp
+++ b/include/snek/ast/parameter.hpp
@@ -65,6 +65,8 @@ namespace snek::ast
       return m_type;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/record.hpp
+++ b/include/snek/ast/record.hpp
@@ -85,6 +85,8 @@ namespace snek::ast::record
       return m_value_expression;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(
       Interpreter& interpreter,
       const Scope& scope,
@@ -115,6 +117,8 @@ namespace snek::ast::record
       return m_value_expression;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(
       Interpreter& interpreter,
       const Scope& scope,
@@ -134,6 +138,11 @@ namespace snek::ast::record
     inline const std::u32string& name() const
     {
       return m_name;
+    }
+
+    inline std::u32string to_string() const
+    {
+      return U"..." + m_name;
     }
 
     result_type eval(
@@ -164,6 +173,8 @@ namespace snek::ast::record
     {
       return m_expression;
     }
+
+    std::u32string to_string() const;
 
     result_type eval(
       Interpreter& interpreter,

--- a/include/snek/ast/stmt/assign.hpp
+++ b/include/snek/ast/stmt/assign.hpp
@@ -49,6 +49,11 @@ namespace snek::ast::stmt
       return m_value;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_target->to_string() + U" = " + m_value->to_string();
+    }
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/block.hpp
+++ b/include/snek/ast/stmt/block.hpp
@@ -44,6 +44,11 @@ namespace snek::ast::stmt
       return m_statements;
     }
 
+    inline std::u32string to_string() const
+    {
+      return U"...";
+    }
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/break.hpp
+++ b/include/snek/ast/stmt/break.hpp
@@ -34,6 +34,11 @@ namespace snek::ast::stmt
   public:
     explicit Break(const Position& position);
 
+    inline std::u32string to_string() const
+    {
+      return U"break";
+    }
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/continue.hpp
+++ b/include/snek/ast/stmt/continue.hpp
@@ -34,6 +34,11 @@ namespace snek::ast::stmt
   public:
     explicit Continue(const Position& position);
 
+    inline std::u32string to_string() const
+    {
+      return U"continue";
+    }
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/export.hpp
+++ b/include/snek/ast/stmt/export.hpp
@@ -50,6 +50,8 @@ namespace snek::ast::stmt
       return m_value;
     }
 
+    std::u32string to_string() const;
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/expr.hpp
+++ b/include/snek/ast/stmt/expr.hpp
@@ -25,9 +25,8 @@
  */
 #pragma once
 
+#include <snek/ast/expr/base.hpp>
 #include <snek/ast/stmt/base.hpp>
-
-namespace snek::ast::expr { class RValue; }
 
 namespace snek::ast::stmt
 {
@@ -43,6 +42,11 @@ namespace snek::ast::stmt
     inline const_reference expression() const
     {
       return m_expression;
+    }
+
+    inline std::u32string to_string() const
+    {
+      return m_expression->to_string();
     }
 
     void exec(

--- a/include/snek/ast/stmt/if.hpp
+++ b/include/snek/ast/stmt/if.hpp
@@ -56,6 +56,8 @@ namespace snek::ast::stmt
       return m_else_statement;
     }
 
+    std::u32string to_string() const;
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/import.hpp
+++ b/include/snek/ast/stmt/import.hpp
@@ -54,6 +54,8 @@ namespace snek::ast::stmt
       return m_specifiers;
     }
 
+    std::u32string to_string() const;
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/pass.hpp
+++ b/include/snek/ast/stmt/pass.hpp
@@ -34,6 +34,11 @@ namespace snek::ast::stmt
   public:
     explicit Pass(const Position& position);
 
+    inline std::u32string to_string() const
+    {
+      return U"pass";
+    }
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/return.hpp
+++ b/include/snek/ast/stmt/return.hpp
@@ -25,9 +25,8 @@
  */
 #pragma once
 
+#include <snek/ast/expr/base.hpp>
 #include <snek/ast/stmt/base.hpp>
-
-namespace snek::ast::expr { class RValue; }
 
 namespace snek::ast::stmt
 {
@@ -42,6 +41,20 @@ namespace snek::ast::stmt
     inline const std::shared_ptr<expr::RValue>& value_expression() const
     {
       return m_value_expression;
+    }
+
+    inline std::u32string to_string() const
+    {
+      std::u32string result;
+
+      result += U"return";
+      if (m_value_expression)
+      {
+        result += U' ';
+        result += m_value_expression->to_string();
+      }
+
+      return result;
     }
 
     void exec(

--- a/include/snek/ast/stmt/type.hpp
+++ b/include/snek/ast/stmt/type.hpp
@@ -56,6 +56,8 @@ namespace snek::ast::stmt
       return m_is_export;
     }
 
+    std::u32string to_string() const;
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/stmt/while.hpp
+++ b/include/snek/ast/stmt/while.hpp
@@ -50,6 +50,8 @@ namespace snek::ast::stmt
       return m_statement;
     }
 
+    std::u32string to_string() const;
+
     void exec(
       Interpreter& interpreter,
       Scope& scope,

--- a/include/snek/ast/type/builtin.hpp
+++ b/include/snek/ast/type/builtin.hpp
@@ -55,6 +55,8 @@ namespace snek::ast::type
       return m_builtin_kind;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/type/func.hpp
+++ b/include/snek/ast/type/func.hpp
@@ -56,6 +56,8 @@ namespace snek::ast::type
       return m_return_type;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/type/list.hpp
+++ b/include/snek/ast/type/list.hpp
@@ -47,6 +47,11 @@ namespace snek::ast::type
       return m_element_type;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_element_type->to_string() + U"[]";
+    }
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/type/multiple.hpp
+++ b/include/snek/ast/type/multiple.hpp
@@ -71,6 +71,8 @@ namespace snek::ast::type
       return m_types;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
     inline const_iterator begin() const

--- a/include/snek/ast/type/named.hpp
+++ b/include/snek/ast/type/named.hpp
@@ -44,6 +44,11 @@ namespace snek::ast::type
       return m_name;
     }
 
+    inline std::u32string to_string() const
+    {
+      return m_name;
+    }
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/type/record.hpp
+++ b/include/snek/ast/type/record.hpp
@@ -56,6 +56,8 @@ namespace snek::ast::type
       return m_fields;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/ast/type/str.hpp
+++ b/include/snek/ast/type/str.hpp
@@ -44,6 +44,8 @@ namespace snek::ast::type
       return m_value;
     }
 
+    std::u32string to_string() const;
+
     result_type eval(const Interpreter& interpreter, const Scope& scope) const;
 
   private:

--- a/include/snek/utils.hpp
+++ b/include/snek/utils.hpp
@@ -25,28 +25,11 @@
  */
 #pragma once
 
-#include <snek/ast/position.hpp>
+#include <cstdint>
+#include <string>
 
-namespace snek::ast
+namespace snek::utils
 {
-  class Node
-  {
-  public:
-    explicit Node(const Position& position);
-
-    inline const Position& position() const
-    {
-      return m_position;
-    }
-
-    virtual std::u32string to_string() const = 0;
-
-    Node(const Node&) = delete;
-    Node(Node&&) = delete;
-    void operator=(const Node&) = delete;
-    void operator=(Node&&) = delete;
-
-  private:
-    const Position m_position;
-  };
+  std::u32string to_string(std::int64_t value);
+  std::u32string to_string(double value);
 }

--- a/src/ast/expr/binary.cpp
+++ b/src/ast/expr/binary.cpp
@@ -34,6 +34,21 @@ namespace snek::ast::expr
 {
   using namespace snek::value::utils;
 
+  static const std::unordered_map<BinaryOperator, std::u32string> mapping =
+  {
+    { BinaryOperator::Add, U"+" },
+    { BinaryOperator::Sub, U"-" },
+    { BinaryOperator::Mul, U"*" },
+    { BinaryOperator::Div, U"/" },
+    { BinaryOperator::Mod, U"%" },
+    { BinaryOperator::Eq, U"==" },
+    { BinaryOperator::Ne, U"!=" },
+    { BinaryOperator::Lt, U"<" },
+    { BinaryOperator::Gt, U">" },
+    { BinaryOperator::Lte, U"<=" },
+    { BinaryOperator::Gte, U">=" },
+  };
+
   Binary::Binary(
     const Position& position,
     const std::shared_ptr<RValue>& left_expression,
@@ -432,6 +447,26 @@ namespace snek::ast::expr
       U" against " +
       right->type(interpreter)->to_string()
     });
+  }
+
+  std::u32string
+  Binary::to_string() const
+  {
+    const auto entry = mapping.find(m_binary_operator);
+    std::u32string result;
+
+    result += m_left_expression->to_string();
+    result += U' ';
+    if (entry != std::end(mapping))
+    {
+      result += entry->second;
+    } else {
+      result += U"unknown";
+    }
+    result += U' ';
+    result += m_right_expression->to_string();
+
+    return result;
   }
 
   RValue::result_type

--- a/src/ast/expr/call.cpp
+++ b/src/ast/expr/call.cpp
@@ -37,6 +37,26 @@ namespace snek::ast::expr
     , m_callee(callee)
     , m_arguments(arguments) {}
 
+  std::u32string
+  Call::to_string() const
+  {
+    std::u32string result;
+
+    result += m_callee->to_string();
+    result += U'(';
+    for (std::size_t i = 0; i < m_arguments.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_arguments[i]->to_string();
+    }
+    result += U')';
+
+    return result;
+  }
+
   RValue::result_type
   Call::eval(Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/expr/float.cpp
+++ b/src/ast/expr/float.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <snek/ast/expr/float.hpp>
+#include <snek/utils.hpp>
 #include <snek/value/float.hpp>
 
 namespace snek::ast::expr
@@ -31,6 +32,12 @@ namespace snek::ast::expr
   Float::Float(const Position& position, value_type value)
     : RValue(position)
     , m_value(value) {}
+
+  std::u32string
+  Float::to_string() const
+  {
+    return utils::to_string(m_value);
+  }
 
   RValue::result_type
   Float::eval(Interpreter&, const Scope&) const

--- a/src/ast/expr/func.cpp
+++ b/src/ast/expr/func.cpp
@@ -41,6 +41,31 @@ namespace snek::ast::expr
     , m_body(body)
     , m_return_type(return_type) {}
 
+  std::u32string
+  Func::to_string() const
+  {
+    std::u32string result;
+
+    result += U'(';
+    for (std::size_t i = 0; i < m_parameters.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_parameters[i]->to_string();
+    }
+    result += U") -> ";
+    if (m_return_type)
+    {
+      result += (*m_return_type)->to_string();
+    } else {
+      result += U"Any";
+    }
+
+    return result;
+  }
+
   RValue::result_type
   Func::eval(Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/expr/int.cpp
+++ b/src/ast/expr/int.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <snek/ast/expr/int.hpp>
+#include <snek/utils.hpp>
 #include <snek/value/int.hpp>
 
 namespace snek::ast::expr
@@ -31,6 +32,12 @@ namespace snek::ast::expr
   Int::Int(const Position& position, value_type value)
     : RValue(position)
     , m_value(value) {}
+
+  std::u32string
+  Int::to_string() const
+  {
+    return utils::to_string(m_value);
+  }
 
   RValue::result_type
   Int::eval(Interpreter&, const Scope&) const

--- a/src/ast/expr/list.cpp
+++ b/src/ast/expr/list.cpp
@@ -36,6 +36,25 @@ namespace snek::ast::expr
     : LValue(position)
     , m_elements(elements) {}
 
+  std::u32string
+  List::to_string() const
+  {
+    std::u32string result;
+
+    result += U'[';
+    for (std::size_t i = 0; i < m_elements.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_elements[i]->to_string();
+    }
+    result += U']';
+
+    return result;
+  }
+
   RValue::result_type
   List::eval(Interpreter& interpreter, const Scope& scope) const
   {
@@ -101,7 +120,9 @@ namespace snek::ast::expr
       } else {
         return assign_result_type({
           target->position(),
-          U"Cannot assign into TODO."
+          U"Cannot assign into `" +
+          target->to_string() +
+          U"'."
         });
       }
     }

--- a/src/ast/expr/record.cpp
+++ b/src/ast/expr/record.cpp
@@ -37,6 +37,25 @@ namespace snek::ast::expr
     : LValue(position)
     , m_fields(fields) {}
 
+  std::u32string
+  Record::to_string() const
+  {
+    std::u32string result;
+
+    result += U'{';
+    for (std::size_t i = 0; i < m_fields.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_fields[i]->to_string();
+    }
+    result += U'}';
+
+    return result;
+  };
+
   RValue::result_type
   Record::eval(Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/expr/str.cpp
+++ b/src/ast/expr/str.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <snek/ast/expr/str.hpp>
+#include <snek/cst.hpp>
 #include <snek/value/str.hpp>
 
 namespace snek::ast::expr
@@ -31,6 +32,12 @@ namespace snek::ast::expr
   Str::Str(const Position& position, const_reference value)
     : RValue(position)
     , m_value(value) {}
+
+  std::u32string
+  Str::to_string() const
+  {
+    return cst::stringify(m_value);
+  }
 
   RValue::result_type
   Str::eval(Interpreter&, const Scope&) const

--- a/src/ast/import.cpp
+++ b/src/ast/import.cpp
@@ -41,6 +41,20 @@ namespace snek::ast::import
     , m_name(name)
     , m_alias(alias) {}
 
+  std::u32string
+  Named::to_string() const
+  {
+    auto result = m_name;
+
+    if (m_alias)
+    {
+      result += U" as ";
+      result += *m_alias;
+    }
+
+    return result;
+  }
+
   Specifier::result_type
   Named::import(
     const Scope& module,

--- a/src/ast/parameter.cpp
+++ b/src/ast/parameter.cpp
@@ -39,6 +39,23 @@ namespace snek::ast
     , m_name(name)
     , m_type(type) {}
 
+  std::u32string
+  Parameter::to_string() const
+  {
+    std::u32string result;
+
+    result += m_name;
+    result += U": ";
+    if (m_type)
+    {
+      result += (*m_type)->to_string();
+    } else {
+      result += U"Any";
+    }
+
+    return result;
+  }
+
   Parameter::result_type
   Parameter::eval(const Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/record.cpp
+++ b/src/ast/record.cpp
@@ -53,6 +53,12 @@ namespace snek::ast::record
     , m_name(name)
     , m_value_expression(value_expression) {}
 
+  std::u32string
+  Named::to_string() const
+  {
+    return m_name + U": " + m_value_expression->to_string();
+  }
+
   Field::result_type
   Named::eval(
     Interpreter& interpreter,
@@ -79,6 +85,17 @@ namespace snek::ast::record
     : Field(position)
     , m_name_expression(name_expression)
     , m_value_expression(value_expression) {}
+
+  std::u32string
+  Expr::to_string() const
+  {
+    return (
+      U'[' +
+      m_name_expression->to_string() +
+      U"]: " +
+      m_value_expression->to_string()
+    );
+  }
 
   Field::result_type
   Expr::eval(
@@ -168,6 +185,12 @@ namespace snek::ast::record
   )
     : Field(position)
     , m_expression(expression) {}
+
+  std::u32string
+  Spread::to_string() const
+  {
+    return U"..." + m_expression->to_string();
+  }
 
   Field::result_type
   Spread::eval(

--- a/src/ast/stmt/export.cpp
+++ b/src/ast/stmt/export.cpp
@@ -38,6 +38,12 @@ namespace snek::ast::stmt
     , m_name(name)
     , m_value(value) {}
 
+  std::u32string
+  Export::to_string() const
+  {
+    return U"export " + m_name + U" = " + m_value->to_string();
+  }
+
   void
   Export::exec(
     Interpreter& interpreter,

--- a/src/ast/stmt/expr.cpp
+++ b/src/ast/stmt/expr.cpp
@@ -23,7 +23,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <snek/ast/expr/base.hpp>
 #include <snek/ast/stmt/expr.hpp>
 
 namespace snek::ast::stmt

--- a/src/ast/stmt/if.cpp
+++ b/src/ast/stmt/if.cpp
@@ -40,6 +40,17 @@ namespace snek::ast::stmt
     , m_then_statement(then_statement)
     , m_else_statement(else_statement) {}
 
+  std::u32string
+  If::to_string() const
+  {
+    return (
+      U"if " +
+      m_condition->to_string() +
+      U": " +
+      m_then_statement->to_string()
+    );
+  }
+
   void
   If::exec(
     Interpreter& interpreter,

--- a/src/ast/stmt/import.cpp
+++ b/src/ast/stmt/import.cpp
@@ -37,6 +37,24 @@ namespace snek::ast::stmt
     , m_path(path)
     , m_specifiers(specifiers) {}
 
+  std::u32string
+  Import::to_string() const
+  {
+    std::u32string result;
+
+    result += U"import ";
+    for (std::size_t i = 0; i > m_specifiers.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_specifiers[i]->to_string();
+    }
+
+    return result;
+  }
+
   void
   Import::exec(
     Interpreter& interpreter,

--- a/src/ast/stmt/type.cpp
+++ b/src/ast/stmt/type.cpp
@@ -40,6 +40,23 @@ namespace snek::ast::stmt
     , m_type(type)
     , m_is_export(is_export) {}
 
+  std::u32string
+  Type::to_string() const
+  {
+    std::u32string result;
+
+    if (m_is_export)
+    {
+      result += U"export ";
+    }
+    result += U" type ";
+    result += m_name;
+    result += U" = ";
+    result += m_type->to_string();
+
+    return result;
+  }
+
   void
   Type::exec(
     Interpreter& interpreter,

--- a/src/ast/stmt/while.cpp
+++ b/src/ast/stmt/while.cpp
@@ -38,6 +38,17 @@ namespace snek::ast::stmt
     , m_condition(condition)
     , m_statement(statement) {}
 
+  std::u32string
+  While::to_string() const
+  {
+    return (
+      U"while " +
+      m_condition->to_string() +
+      U": " +
+      m_statement->to_string()
+    );
+  }
+
   void
   While::exec(
     Interpreter& interpreter,

--- a/src/ast/type/builtin.cpp
+++ b/src/ast/type/builtin.cpp
@@ -28,9 +28,28 @@
 
 namespace snek::ast::type
 {
+  static const std::unordered_map<BuiltinKind, std::u32string> mapping =
+  {
+    { BuiltinKind::Any, U"Any" },
+    { BuiltinKind::Bool, U"Bool" },
+    { BuiltinKind::Float, U"Float" },
+    { BuiltinKind::Int, U"Int" },
+    { BuiltinKind::Num, U"Num" },
+    { BuiltinKind::Str, U"Str" },
+    { BuiltinKind::Void, U"Void" },
+  };
+
   Builtin::Builtin(const Position& position, BuiltinKind builtin_kind)
     : Base(position)
     , m_builtin_kind(builtin_kind) {}
+
+  std::u32string
+  Builtin::to_string() const
+  {
+    const auto entry = mapping.find(m_builtin_kind);
+
+    return entry != std::end(mapping) ? entry->second : U"Any";
+  }
 
   Base::result_type
   Builtin::eval(const Interpreter& interpreter, const Scope&) const

--- a/src/ast/type/func.cpp
+++ b/src/ast/type/func.cpp
@@ -38,6 +38,30 @@ namespace snek::ast::type
     , m_parameters(parameters)
     , m_return_type(return_type) {}
 
+  std::u32string
+  Func::to_string() const
+  {
+    std::u32string result;
+
+    result += U'(';
+    for (std::size_t i = 0; i < m_parameters.size(); ++i)
+    {
+      if (i > 0)
+      {
+        result += U", ";
+      }
+      result += m_parameters[i]->to_string();
+    }
+    result += U')';
+    if (m_return_type)
+    {
+      result += U" -> ";
+      result += (*m_return_type)->to_string();
+    }
+
+    return result;
+  }
+
   Base::result_type
   Func::eval(const Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/type/multiple.cpp
+++ b/src/ast/type/multiple.cpp
@@ -39,6 +39,40 @@ namespace snek::ast::type
     , m_multiple_kind(multiple_kind)
     , m_types(types) {}
 
+  std::u32string
+  Multiple::to_string() const
+  {
+    std::u32string result;
+
+    if (m_multiple_kind == MultipleKind::Tuple)
+    {
+      result += U'[';
+    }
+    for (std::size_t i = 0; i < m_types.size(); ++i)
+    {
+      if (i > 0)
+      {
+        if (m_multiple_kind == MultipleKind::Intersection)
+        {
+          result += U" & ";
+        }
+        else if (m_multiple_kind == MultipleKind::Union)
+        {
+          result += U" | ";
+        } else {
+          result += U", ";
+        }
+      }
+      result += m_types[i]->to_string();
+    }
+    if (m_multiple_kind == MultipleKind::Tuple)
+    {
+      result += U']';
+    }
+
+    return result;
+  }
+
   Base::result_type
   Multiple::eval(const Interpreter& interpreter, const Scope& scope) const
   {
@@ -65,7 +99,7 @@ namespace snek::ast::type
       case MultipleKind::Tuple:
         return result_type::ok(std::make_shared<snek::type::Tuple>(types));
 
-      case MultipleKind::Union:
+      default:
         return result_type::ok(std::make_shared<snek::type::Union>(types));
     };
   }

--- a/src/ast/type/record.cpp
+++ b/src/ast/type/record.cpp
@@ -35,6 +35,30 @@ namespace snek::ast::type
     : Base(position)
     , m_fields(fields) {}
 
+  std::u32string
+  Record::to_string() const
+  {
+    std::u32string result;
+    bool first = true;
+
+    result += U'{';
+    for (const auto& field : m_fields)
+    {
+      if (first)
+      {
+        first = false;
+      } else {
+        result += U", ";
+      }
+      result += field.first;
+      result += U": ";
+      result += field.second->to_string();
+    }
+    result += U'}';
+
+    return result;
+  }
+
   Base::result_type
   Record::eval(const Interpreter& interpreter, const Scope& scope) const
   {

--- a/src/ast/type/str.cpp
+++ b/src/ast/type/str.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <snek/ast/type/str.hpp>
+#include <snek/cst.hpp>
 #include <snek/type/str.hpp>
 
 namespace snek::ast::type
@@ -31,6 +32,12 @@ namespace snek::ast::type
   Str::Str(const Position& position, const std::u32string& value)
     : Base(position)
     , m_value(value) {}
+
+  std::u32string
+  Str::to_string() const
+  {
+    return cst::stringify(m_value);
+  }
 
   Base::result_type
   Str::eval(const Interpreter&, const Scope& scope) const


### PR DESCRIPTION
For debugging reasons, it's a good idea to have AST nodes convertible
into strings.