### PR TITLE
Add support for optional chaining

### DIFF
--- a/include/snek/ast/expr/call.hpp
+++ b/include/snek/ast/expr/call.hpp
@@ -37,7 +37,8 @@ namespace snek::ast::expr
     explicit Call(
       const Position& position,
       const std::shared_ptr<RValue>& callee,
-      const std::vector<std::shared_ptr<RValue>>& arguments
+      const std::vector<std::shared_ptr<RValue>>& arguments,
+      bool optional
     );
 
     inline const std::shared_ptr<RValue>& callee() const
@@ -50,6 +51,11 @@ namespace snek::ast::expr
       return m_arguments;
     }
 
+    inline bool is_optional() const
+    {
+      return m_optional;
+    }
+
     std::u32string to_string() const;
 
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
@@ -57,5 +63,6 @@ namespace snek::ast::expr
   private:
     const std::shared_ptr<RValue> m_callee;
     const std::vector<std::shared_ptr<RValue>> m_arguments;
+    const bool m_optional;
   };
 }

--- a/include/snek/ast/expr/field.hpp
+++ b/include/snek/ast/expr/field.hpp
@@ -35,7 +35,8 @@ namespace snek::ast::expr
     explicit Field(
       const Position& position,
       const std::shared_ptr<RValue>& record_expression,
-      const std::u32string& field
+      const std::u32string& field,
+      bool optional
     );
 
     inline const std::shared_ptr<RValue>& record_expression() const
@@ -48,15 +49,18 @@ namespace snek::ast::expr
       return m_field;
     }
 
-    inline std::u32string to_string() const
+    inline bool is_optional() const
     {
-      return m_record_expression->to_string() + U'.' + m_field;
+      return m_optional;
     }
+
+    std::u32string to_string() const;
 
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:
     const std::shared_ptr<RValue> m_record_expression;
     const std::u32string m_field;
+    const bool m_optional;
   };
 }

--- a/include/snek/ast/expr/subscript.hpp
+++ b/include/snek/ast/expr/subscript.hpp
@@ -35,7 +35,8 @@ namespace snek::ast::expr
     explicit Subscript(
       const Position& position,
       const std::shared_ptr<RValue>& record_expression,
-      const std::shared_ptr<RValue>& field_expression
+      const std::shared_ptr<RValue>& field_expression,
+      bool optional
     );
 
     inline const std::shared_ptr<RValue>& record_expression() const
@@ -48,18 +49,18 @@ namespace snek::ast::expr
       return m_field_expression;
     }
 
-    inline std::u32string to_string() const
+    inline bool is_optional() const
     {
-      return m_record_expression->to_string() +
-        U'[' +
-        m_field_expression->to_string() +
-        U']';
+      return m_optional;
     }
+
+    std::u32string to_string() const;
 
     result_type eval(Interpreter& interpreter, const Scope& scope) const;
 
   private:
     const std::shared_ptr<RValue> m_record_expression;
     const std::shared_ptr<RValue> m_field_expression;
+    const bool m_optional;
   };
 }

--- a/include/snek/cst.hpp
+++ b/include/snek/cst.hpp
@@ -48,6 +48,7 @@ namespace snek::cst
     LeftBrace,
     RightBrace,
     Dot,
+    ConditionalDot,
     Comma,
     Colon,
     Semicolon,

--- a/src/cst.cpp
+++ b/src/cst.cpp
@@ -170,6 +170,9 @@ namespace snek::cst
       case Kind::Dot:
         return U"`.'";
 
+      case Kind::ConditionalDot:
+        return U"`?.'";
+
       case Kind::Comma:
         return U"`,'";
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -710,6 +710,17 @@ namespace snek::lexer
           : cst::Kind::Gt;
         break;
 
+      case '?':
+        if (!state.peek_read('.'))
+        {
+          return token_result_type::error({
+            position,
+            U"Unexpected `?'.",
+          });
+        }
+        kind = cst::Kind::ConditionalDot;
+        break;
+
       default:
         return token_result_type::error({
           position,


### PR DESCRIPTION
Extend the syntax with `?.` operator that can be used to optional chain
field access and function invocation.