### PR TITLE
Get rid of accessor methods

### DIFF
--- a/debug/src/lexer.cpp
+++ b/debug/src/lexer.cpp
@@ -41,9 +41,9 @@ PrintToken(const Token& token)
 {
   using peelo::unicode::encoding::utf8::encode;
 
-  if (const auto position = token.position())
+  if (token.position)
   {
-    std::cout << encode(position->ToString()) << ": ";
+    std::cout << encode(token.position->ToString()) << ": ";
   }
   std::cout << encode(token.ToString()) << std::endl;
 }

--- a/debug/src/parser.cpp
+++ b/debug/src/parser.cpp
@@ -44,9 +44,9 @@ PrintNode(const std::shared_ptr<Node>& node)
   {
     return;
   }
-  if (const auto position = node->position())
+  if (node->position)
   {
-    std::cout << encode(position->ToString()) << ": ";
+    std::cout << encode(node->position->ToString()) << ": ";
   }
   std::cout << encode(node->ToString()) << std::endl;
 }

--- a/interpreter/include/snek/interpreter/value.hpp
+++ b/interpreter/include/snek/interpreter/value.hpp
@@ -214,33 +214,27 @@ namespace snek::interpreter::value
   public:
     using value_type = bool;
 
-    explicit Boolean(bool value)
-      : m_value(value) {}
+    const value_type value;
+
+    explicit Boolean(bool value_)
+      : value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Boolean;
     }
 
-    inline value_type value() const
-    {
-      return m_value;
-    }
-
     bool Equals(const Base& that) const override;
 
     inline std::u32string ToString() const override
     {
-      return m_value ? U"true" : U"false";
+      return value ? U"true" : U"false";
     }
 
     inline std::u32string ToSource() const override
     {
       return ToString();
     }
-
-  private:
-    const value_type m_value;
   };
 
   class Float final : public Number
@@ -248,32 +242,26 @@ namespace snek::interpreter::value
   public:
     using value_type = float_type;
 
-    explicit Float(value_type value)
-      : m_value(value) {}
+    const value_type value;
+
+    explicit Float(value_type value_)
+      : value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Float;
     }
 
-    inline value_type value() const
-    {
-      return m_value;
-    }
-
     int_type ToInt() const override;
 
     inline float_type ToFloat() const override
     {
-      return m_value;
+      return value;
     }
 
     bool Equals(const Base& that) const override;
 
     std::u32string ToString() const override;
-
-  private:
-    const value_type m_value;
   };
 
   class Function : public Base
@@ -347,35 +335,29 @@ namespace snek::interpreter::value
   public:
     using value_type = int_type;
 
-    explicit Int(value_type value)
-      : m_value(value) {}
+    const value_type value;
+
+    explicit Int(value_type value_)
+      : value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Int;
     }
 
-    inline value_type value() const
-    {
-      return m_value;
-    }
-
     inline int_type ToInt() const override
     {
-      return m_value;
+      return value;
     }
 
     inline float_type ToFloat() const override
     {
-      return static_cast<float_type>(m_value);
+      return static_cast<float_type>(value);
     }
 
     bool Equals(const Base& that) const override;
 
     std::u32string ToString() const override;
-
-  private:
-    const std::int64_t m_value;
   };
 
   class List : public Base

--- a/interpreter/src/assign.cpp
+++ b/interpreter/src/assign.cpp
@@ -53,8 +53,7 @@ namespace snek::interpreter
     const callback_type& callback
   )
   {
-    const auto& elements = variable->elements();
-    const auto size = elements.size();
+    const auto size = variable->elements.size();
     value::List::size_type list_size;
     const value::List* list;
 
@@ -76,11 +75,11 @@ namespace snek::interpreter
     }
     for (std::size_t i = 0; i < size; ++i)
     {
-      const auto& element = elements[i];
+      const auto& element = variable->elements[i];
 
-      if (element->kind() == parser::element::Kind::Value)
+      if (element->kind == parser::element::Kind::Value)
       {
-        Process(runtime, element->expression(), list->At(i), callback);
+        Process(runtime, element->expression, list->At(i), callback);
       } else {
         std::vector<value::ptr> result;
 
@@ -96,7 +95,7 @@ namespace snek::interpreter
         while (i < list_size);
         Process(
           runtime,
-          element->expression(),
+          element->expression,
           value::List::Make(result),
           callback
         );
@@ -112,8 +111,7 @@ namespace snek::interpreter
     const callback_type& callback
   )
   {
-    const auto& fields = variable->fields();
-    const auto size = fields.size();
+    const auto size = variable->fields.size();
     std::unordered_set<std::u32string> used_keys;
 
     if (!value::IsRecord(value))
@@ -128,7 +126,7 @@ namespace snek::interpreter
     }
     for (std::size_t i = 0; i < size; ++i)
     {
-      const auto& field = fields[i];
+      const auto& field = variable->fields[i];
       const auto kind = field->kind();
 
       if (kind == parser::field::Kind::Named)
@@ -136,7 +134,7 @@ namespace snek::interpreter
         const auto named = static_cast<const parser::field::Named*>(
           field.get()
         );
-        const auto& name = named->name();
+        const auto& name = named->name;
         const auto property = value::GetProperty(runtime, value, name);
 
         if (!property)
@@ -148,14 +146,14 @@ namespace snek::interpreter
             U"'."
           );
         }
-        Process(runtime, named->value(), *property, callback);
+        Process(runtime, named->value, *property, callback);
         used_keys.insert(name);
       }
       else if (kind == parser::field::Kind::Shorthand)
       {
         const auto& name = static_cast<const parser::field::Shorthand*>(
           field.get()
-        )->name();
+        )->name;
         const auto property = value::GetProperty(runtime, value, name);
 
         if (!property)
@@ -190,14 +188,14 @@ namespace snek::interpreter
         }
         Process(
           runtime,
-          static_cast<const parser::field::Spread*>(field.get())->expression(),
+          static_cast<const parser::field::Spread*>(field.get())->expression,
           value::Record::Make(result),
           callback
         );
       } else {
         throw runtime.MakeError(
           U"Cannot assign to " +
-          fields[i]->ToString() +
+          variable->fields[i]->ToString() +
           U"."
         );
       }
@@ -223,7 +221,7 @@ namespace snek::interpreter
         callback(
           static_cast<const parser::expression::Id*>(
             variable.get()
-          )->identifier(),
+          )->identifier,
           value
         );
         break;

--- a/interpreter/src/prototype/boolean.cpp
+++ b/interpreter/src/prototype/boolean.cpp
@@ -41,7 +41,7 @@ namespace snek::interpreter::prototype
     thread_local static std::mt19937 generator(device());
 
     std::bernoulli_distribution d(
-      static_cast<const value::Float*>(arguments[0].get())->value()
+      static_cast<const value::Float*>(arguments[0].get())->value
     );
 
     return runtime.MakeBoolean(d(generator));

--- a/interpreter/src/prototype/int.cpp
+++ b/interpreter/src/prototype/int.cpp
@@ -38,7 +38,7 @@ namespace snek::interpreter::prototype
   static inline std::int64_t
   AsInt(const value::ptr& value)
   {
-    return static_cast<const value::Int*>(value.get())->value();
+    return static_cast<const value::Int*>(value.get())->value;
   }
 
   /**
@@ -122,5 +122,3 @@ namespace snek::interpreter::prototype
     );
   }
 }
-
-

--- a/interpreter/src/prototype/list.cpp
+++ b/interpreter/src/prototype/list.cpp
@@ -43,7 +43,7 @@ namespace snek::interpreter::prototype
   )
   {
     const auto size = list->GetSize();
-    auto index = static_cast<const value::Int*>(index_value.get())->value();
+    auto index = static_cast<const value::Int*>(index_value.get())->value;
 
     if (index < 0)
     {
@@ -475,7 +475,7 @@ namespace snek::interpreter::prototype
   Repeat(Runtime&, const std::vector<value::ptr>& arguments)
   {
     const auto count = static_cast<std::size_t>(
-      As<value::Int>(arguments[1])->value()
+      As<value::Int>(arguments[1])->value
     );
 
     if (count == 1)

--- a/interpreter/src/prototype/number.cpp
+++ b/interpreter/src/prototype/number.cpp
@@ -363,12 +363,12 @@ namespace snek::interpreter::prototype
     if (value::IsFloat(arguments[0]))
     {
       return std::make_shared<value::Float>(
-        -static_cast<const value::Float*>(arguments[0].get())->value()
+        -static_cast<const value::Float*>(arguments[0].get())->value
       );
     }
 
     return runtime.MakeInt(
-      -static_cast<const value::Int*>(arguments[0].get())->value()
+      -static_cast<const value::Int*>(arguments[0].get())->value
     );
   }
 

--- a/interpreter/src/prototype/string.cpp
+++ b/interpreter/src/prototype/string.cpp
@@ -45,7 +45,7 @@ namespace snek::interpreter::prototype
   )
   {
     const auto length = string->GetLength();
-    auto index = static_cast<const value::Int*>(index_value.get())->value();
+    auto index = static_cast<const value::Int*>(index_value.get())->value;
 
     if (index < 0)
     {
@@ -431,7 +431,7 @@ namespace snek::interpreter::prototype
   Repeat(Runtime&, const std::vector<value::ptr>& arguments)
   {
     const auto count = static_cast<std::size_t>(
-      static_cast<const value::Int*>(arguments[1].get())->value()
+      static_cast<const value::Int*>(arguments[1].get())->value
     );
 
     if (count == 1)

--- a/interpreter/src/resolve/expression.cpp
+++ b/interpreter/src/resolve/expression.cpp
@@ -52,9 +52,9 @@ namespace snek::interpreter
     const Assign* expression
   )
   {
-    return expression->op()
+    return expression->op
       ? nullptr
-      : ResolveExpression(runtime, scope, expression->value());
+      : ResolveExpression(runtime, scope, expression->value);
   }
 
   static type::ptr
@@ -64,15 +64,15 @@ namespace snek::interpreter
     const Binary* expression
   )
   {
-    switch (expression->op())
+    switch (expression->op)
     {
       case Binary::Operator::LogicalAnd:
       case Binary::Operator::LogicalOr:
         return type::Reify(
           runtime,
           {
-            ResolveExpression(runtime, scope, expression->left()),
-            ResolveExpression(runtime, scope, expression->right()),
+            ResolveExpression(runtime, scope, expression->left),
+            ResolveExpression(runtime, scope, expression->right),
             runtime.boolean_type(),
             runtime.void_type()
           }
@@ -93,7 +93,7 @@ namespace snek::interpreter
     const auto type = ResolveExpression(
       runtime,
       scope,
-      expression->expression()
+      expression->expression
     );
 
     if (type && type->kind() == type::Kind::Function)
@@ -102,7 +102,7 @@ namespace snek::interpreter
 
       if (const auto return_type = function->return_type())
       {
-        if (expression->conditional())
+        if (expression->conditional)
         {
           return std::make_shared<type::Union>(
             std::vector<type::ptr>{
@@ -130,15 +130,15 @@ namespace snek::interpreter
   {
     type::ptr return_type;
 
-    if (const auto unresolved_return_type = expression->return_type())
+    if (expression->return_type)
     {
-      return_type = ResolveType(runtime, scope, unresolved_return_type);
+      return_type = ResolveType(runtime, scope, expression->return_type);
     } else {
-      return_type = ResolveStatement(runtime, scope, expression->body());
+      return_type = ResolveStatement(runtime, scope, expression->body);
     }
 
     return std::make_shared<type::Function>(
-      ResolveParameterList(runtime, scope, expression->parameters()),
+      ResolveParameterList(runtime, scope, expression->parameters),
       return_type
     );
   }
@@ -151,13 +151,13 @@ namespace snek::interpreter
     std::vector<type::ptr>& resolved_elements
   )
   {
-    const auto type = ResolveExpression(runtime, scope, element->expression());
+    const auto type = ResolveExpression(runtime, scope, element->expression);
 
     if (!type)
     {
       return false;
     }
-    else if (element->kind() == parser::element::Kind::Spread)
+    else if (element->kind == parser::element::Kind::Spread)
     {
       if (type->kind() == type::Kind::Tuple)
       {
@@ -188,7 +188,7 @@ namespace snek::interpreter
   {
     std::vector<type::ptr> resolved_elements;
 
-    for (const auto& element : expression->elements())
+    for (const auto& element : expression->elements)
     {
       if (!ResolveElement(runtime, scope, element, resolved_elements))
       {
@@ -209,17 +209,17 @@ namespace snek::interpreter
     const auto type = ResolveExpression(
       runtime,
       scope,
-      expression->expression()
+      expression->expression
     );
 
     if (type && type->kind() == type::Kind::Record)
     {
       const auto& fields = As<type::Record>(type)->fields();
-      const auto it = fields.find(expression->name());
+      const auto it = fields.find(expression->name);
 
       if (it != std::end(fields))
       {
-        return expression->conditional()
+        return expression->conditional
           ? std::make_shared<type::Union>(std::vector<type::ptr>{
             it->second,
             runtime.void_type()
@@ -240,7 +240,7 @@ namespace snek::interpreter
   {
     type::Record::container_type resolved_fields;
 
-    for (const auto& field : expression->fields())
+    for (const auto& field : expression->fields)
     {
       if (!ResolveField(runtime, scope, field, resolved_fields))
       {
@@ -258,11 +258,12 @@ namespace snek::interpreter
     const Ternary* expression
   )
   {
+    // TODO: Check if condition is constant.
     return type::Reify(
       runtime,
       {
-        ResolveExpression(runtime, scope, expression->then_expression()),
-        ResolveExpression(runtime, scope, expression->else_expression()),
+        ResolveExpression(runtime, scope, expression->then_expression),
+        ResolveExpression(runtime, scope, expression->else_expression),
       }
     );
   }
@@ -274,7 +275,7 @@ namespace snek::interpreter
     const Unary* expression
   )
   {
-    return expression->op() == Unary::Operator::Not
+    return expression->op == Unary::Operator::Not
       ? runtime.boolean_type()
       : nullptr;
   }
@@ -341,7 +342,7 @@ namespace snek::interpreter
         return nullptr;
 
       case Kind::String:
-        return std::make_shared<type::String>(As<String>(expression)->value());
+        return std::make_shared<type::String>(As<String>(expression)->value);
 
       // TODO: Add special case for lists and records where an element/field
       // lookup is done.

--- a/interpreter/src/resolve/field.cpp
+++ b/interpreter/src/resolve/field.cpp
@@ -52,14 +52,14 @@ namespace snek::interpreter
     type::Record::container_type& resolved_fields
   )
   {
-    const auto key_type = ResolveExpression(runtime, scope, field->key());
+    const auto key_type = ResolveExpression(runtime, scope, field->key);
 
     if (key_type && key_type->kind() == type::Kind::String)
     {
       const auto value_type = ResolveExpression(
         runtime,
         scope,
-        field->value()
+        field->value
       );
 
       if (!value_type)
@@ -82,9 +82,9 @@ namespace snek::interpreter
     type::Record::container_type& resolved_fields
   )
   {
-    resolved_fields[field->name()] = std::make_shared<type::Function>(
-      ResolveParameterList(runtime, scope, field->parameters()),
-      ResolveType(runtime, scope, field->return_type())
+    resolved_fields[field->name] = std::make_shared<type::Function>(
+      ResolveParameterList(runtime, scope, field->parameters),
+      ResolveType(runtime, scope, field->return_type)
     );
 
     return true;
@@ -98,13 +98,13 @@ namespace snek::interpreter
     type::Record::container_type& resolved_fields
   )
   {
-    const auto type = ResolveExpression(runtime, scope, field->value());
+    const auto type = ResolveExpression(runtime, scope, field->value);
 
     if (!type)
     {
       return false;
     }
-    resolved_fields[field->name()] = type;
+    resolved_fields[field->name] = type;
 
     return true;
   }
@@ -121,8 +121,8 @@ namespace snek::interpreter
       runtime,
       scope,
       std::make_shared<parser::expression::Id>(
-        field->position(),
-        field->name()
+        field->position,
+        field->name
       )
     );
 
@@ -146,7 +146,7 @@ namespace snek::interpreter
     type::Record::container_type& resolved_fields
   )
   {
-    const auto type = ResolveExpression(runtime, scope, field->expression());
+    const auto type = ResolveExpression(runtime, scope, field->expression);
 
     if (type && type->kind() == type::Kind::Record)
     {

--- a/interpreter/src/resolve/parameter.cpp
+++ b/interpreter/src/resolve/parameter.cpp
@@ -35,11 +35,11 @@ namespace snek::interpreter
   )
   {
     return {
-      parameter.name(),
-      ResolveType(runtime, scope, parameter.type()),
-      parameter.default_value(),
-      parameter.rest(),
-      parameter.position()
+      parameter.name,
+      ResolveType(runtime, scope, parameter.type),
+      parameter.default_value,
+      parameter.rest,
+      parameter.position
     };
   }
 

--- a/interpreter/src/resolve/statement.cpp
+++ b/interpreter/src/resolve/statement.cpp
@@ -48,9 +48,11 @@ namespace snek::interpreter
     std::vector<parser::expression::ptr>& values
   )
   {
-    for (const auto& child : statement->statements())
+    const auto size = statement->statements.size();
+
+    for (std::size_t i = 0; i < size; ++i)
     {
-      FindReturnValues(child, values);
+      FindReturnValues(statement->statements[i], values);
     }
   }
 
@@ -60,8 +62,8 @@ namespace snek::interpreter
     std::vector<parser::expression::ptr>& values
   )
   {
-    FindReturnValues(statement->then_statement(), values);
-    FindReturnValues(statement->else_statement(), values);
+    FindReturnValues(statement->then_statement, values);
+    FindReturnValues(statement->else_statement, values);
   }
 
   static void
@@ -70,13 +72,13 @@ namespace snek::interpreter
     std::vector<parser::expression::ptr>& values
   )
   {
-    if (statement->jump_kind() != JumpKind::Return)
+    if (statement->jump_kind != JumpKind::Return)
     {
       return;
     }
-    if (const auto value = statement->value())
+    if (statement->value)
     {
-      values.push_back(value);
+      values.push_back(statement->value);
     }
   }
 
@@ -106,7 +108,7 @@ namespace snek::interpreter
         break;
 
       case Kind::While:
-        FindReturnValues(As<While>(statement)->body(), values);
+        FindReturnValues(As<While>(statement)->body, values);
         break;
 
       default:
@@ -142,9 +144,9 @@ namespace snek::interpreter
     const DeclareVar* statement
   )
   {
-    if (const auto value = statement->value())
+    if (statement->value)
     {
-      return ResolveExpression(runtime, scope, value);
+      return ResolveExpression(runtime, scope, statement->value);
     }
 
     return nullptr;
@@ -180,7 +182,7 @@ namespace snek::interpreter
         return ResolveExpression(
           runtime,
           scope,
-          As<Expression>(statement)->expression()
+          As<Expression>(statement)->expression
         );
 
       case Kind::Import:

--- a/interpreter/src/resolve/type.cpp
+++ b/interpreter/src/resolve/type.cpp
@@ -45,8 +45,8 @@ namespace snek::interpreter
   )
   {
     return std::make_shared<type::Function>(
-      ResolveParameterList(runtime, scope, type->parameters()),
-      ResolveType(runtime, scope, type->return_type())
+      ResolveParameterList(runtime, scope, type->parameters),
+      ResolveType(runtime, scope, type->return_type)
     );
   }
 
@@ -57,16 +57,15 @@ namespace snek::interpreter
     const Multiple* type
   )
   {
-    const auto& types = type->types();
     type::Multiple::container_type resolved_types;
 
-    resolved_types.reserve(types.size());
-    for (const auto& subtype : type->types())
+    resolved_types.reserve(type->types.size());
+    for (const auto& subtype : type->types)
     {
       resolved_types.push_back(ResolveType(runtime, scope, subtype));
     }
 
-    switch (type->multiple_kind())
+    switch (type->multiple_kind)
     {
       case Multiple::MultipleKind::Intersection:
         return std::make_shared<type::Intersection>(resolved_types);
@@ -88,9 +87,7 @@ namespace snek::interpreter
     const Named* type
   )
   {
-    const auto& name = type->name();
-
-    if (!name.compare(U"any"))
+    if (!type->name.compare(U"any"))
     {
       return runtime.any_type();
     }
@@ -98,13 +95,13 @@ namespace snek::interpreter
     {
       type::ptr slot;
 
-      if (scope->FindType(name, slot))
+      if (scope->FindType(type->name, slot))
       {
         return slot;
       }
     }
 
-    throw runtime.MakeError(U"Unknown type: `" + name + U"'.");
+    throw runtime.MakeError(U"Unknown type: `" + type->name + U"'.");
   }
 
   static type::ptr
@@ -116,7 +113,7 @@ namespace snek::interpreter
   {
     type::Record::container_type fields;
 
-    for (const auto& field : type->fields())
+    for (const auto& field : type->fields)
     {
       fields[field.first] = ResolveType(runtime, scope, field.second);
     }
@@ -139,7 +136,7 @@ namespace snek::interpreter
     switch (type->kind())
     {
       case Kind::Boolean:
-        return std::make_shared<type::Boolean>(As<Boolean>(type)->value());
+        return std::make_shared<type::Boolean>(As<Boolean>(type)->value);
 
       case Kind::Function:
         return ResolveFunction(runtime, scope, As<Function>(type));
@@ -149,7 +146,7 @@ namespace snek::interpreter
           ResolveType(
             runtime,
             scope,
-            As<List>(type)->element_type()
+            As<List>(type)->element_type
           )
         );
 
@@ -166,7 +163,7 @@ namespace snek::interpreter
         return ResolveRecord(runtime, scope, As<Record>(type));
 
       case Kind::String:
-        return std::make_shared<type::String>(As<String>(type)->value());
+        return std::make_shared<type::String>(As<String>(type)->value);
     }
 
     return nullptr;

--- a/interpreter/src/type.cpp
+++ b/interpreter/src/type.cpp
@@ -106,7 +106,7 @@ namespace snek::interpreter::type
   {
     if (value::IsBoolean(value))
     {
-      return As<value::Boolean>(value)->value() == m_value;
+      return As<value::Boolean>(value)->value == m_value;
     }
 
     return false;

--- a/interpreter/src/value.cpp
+++ b/interpreter/src/value.cpp
@@ -190,7 +190,7 @@ namespace snek::interpreter::value
     }
     else if (value->kind() == Kind::Boolean)
     {
-      return As<Boolean>(value)->value();
+      return As<Boolean>(value)->value;
     }
 
     return true;

--- a/interpreter/src/value/boolean.cpp
+++ b/interpreter/src/value/boolean.cpp
@@ -32,7 +32,7 @@ namespace snek::interpreter::value
   {
     return (
       that.kind() == Kind::Boolean &&
-      static_cast<const Boolean*>(&that)->m_value == m_value
+      static_cast<const Boolean*>(&that)->value == value
     );
   }
 }

--- a/interpreter/src/value/float.cpp
+++ b/interpreter/src/value/float.cpp
@@ -33,18 +33,18 @@ namespace snek::interpreter::value
   Number::int_type
   Float::ToInt() const
   {
-    auto value = m_value;
+    auto v = value;
 
-    if (value > 0.0)
+    if (v > 0.0)
     {
-      value = std::floor(value);
+      v = std::floor(value);
     }
-    if (value < 0.0)
+    if (v < 0.0)
     {
-      value = std::ceil(value);
+      v = std::ceil(value);
     }
 
-    return static_cast<int_type>(value);
+    return static_cast<int_type>(v);
   }
 
   bool
@@ -53,10 +53,10 @@ namespace snek::interpreter::value
     switch (that.kind())
     {
       case Kind::Int:
-        return m_value == static_cast<const Int*>(&that)->value();
+        return value == static_cast<const Int*>(&that)->value;
 
       case Kind::Float:
-        return m_value == static_cast<const Float*>(&that)->m_value;
+        return value == static_cast<const Float*>(&that)->value;
 
       default:
         return false;
@@ -66,6 +66,6 @@ namespace snek::interpreter::value
   std::u32string
   Float::ToString() const
   {
-    return parser::utils::DoubleToString(m_value);
+    return parser::utils::DoubleToString(value);
   }
 }

--- a/interpreter/src/value/int.cpp
+++ b/interpreter/src/value/int.cpp
@@ -34,10 +34,10 @@ namespace snek::interpreter::value
     switch (that.kind())
     {
       case Kind::Int:
-        return m_value == static_cast<const Int*>(&that)->m_value;
+        return value == static_cast<const Int*>(&that)->value;
 
       case Kind::Float:
-        return m_value == static_cast<const Float*>(&that)->value();
+        return value == static_cast<const Float*>(&that)->value;
 
       default:
         return false;
@@ -47,6 +47,6 @@ namespace snek::interpreter::value
   std::u32string
   Int::ToString() const
   {
-    return parser::utils::IntToString(m_value);
+    return parser::utils::IntToString(value);
   }
 }

--- a/parser/include/snek/parser/element.hpp
+++ b/parser/include/snek/parser/element.hpp
@@ -49,30 +49,19 @@ namespace snek::parser::element
   public:
     DISALLOW_COPY_AND_ASSIGN(Base);
 
+    const Kind kind;
+    const expression::ptr expression;
+
     explicit Base(
       const std::optional<Position>& position,
-      Kind kind,
-      const expression::ptr& expression
+      Kind kind_,
+      const expression::ptr& expression_
     )
       : Node(position)
-      , m_kind(kind)
-      , m_expression(expression) {}
-
-    inline Kind kind() const
-    {
-      return m_kind;
-    };
-
-    inline const expression::ptr& expression() const
-    {
-      return m_expression;
-    }
+      , kind(kind_)
+      , expression(expression_) {}
 
     std::u32string ToString() const override;
-
-  private:
-    const Kind m_kind;
-    const expression::ptr m_expression;
   };
 
   using ptr = std::shared_ptr<Base>;

--- a/parser/include/snek/parser/expression.hpp
+++ b/parser/include/snek/parser/expression.hpp
@@ -124,45 +124,29 @@ namespace snek::parser::expression
       NullCoalescing = static_cast<int>(Token::Kind::AssignNullCoalescing),
     };
 
+    const ptr variable;
+    const ptr value;
+    const std::optional<Operator> op;
+
     explicit Assign(
       const std::optional<Position>& position,
-      const ptr& variable,
-      const ptr& value,
-      const std::optional<Operator>& op = std::nullopt
+      const ptr& variable_,
+      const ptr& value_,
+      const std::optional<Operator>& op_ = std::nullopt
     )
       : Base(position)
-      , m_variable(variable)
-      , m_value(value)
-      , m_op(op) {}
+      , variable(variable_)
+      , value(value_)
+      , op(op_) {}
 
     inline Kind kind() const override
     {
       return Kind::Assign;
     }
 
-    inline const ptr& variable() const
-    {
-      return m_variable;
-    }
-
-    inline const ptr& value() const
-    {
-      return m_value;
-    }
-
-    inline const std::optional<Operator>& op() const
-    {
-      return m_op;
-    }
-
     static std::u32string ToString(Operator op);
 
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_variable;
-    const ptr m_value;
-    const std::optional<Operator> m_op;
   };
 
   class Binary final : public Base
@@ -191,227 +175,153 @@ namespace snek::parser::expression
       NullCoalescing = static_cast<int>(Token::Kind::NullCoalescing),
     };
 
-    explicit Binary(const ptr& left, Operator op, const ptr& right)
-      : Base(left->position())
-      , m_left(left)
-      , m_op(op)
-      , m_right(right) {}
+    const ptr left;
+    const Operator op;
+    const ptr right;
+
+    explicit Binary(const ptr& left_, Operator op_, const ptr& right_)
+      : Base(left_->position)
+      , left(left_)
+      , op(op_)
+      , right(right_) {}
 
     inline Kind kind() const override
     {
       return Kind::Binary;
     }
 
-    inline const ptr& left() const
-    {
-      return m_left;
-    }
-
-    inline Operator op() const
-    {
-      return m_op;
-    }
-
-    inline const ptr& right() const
-    {
-      return m_right;
-    }
-
     static std::u32string ToString(Operator op);
 
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_left;
-    const Operator m_op;
-    const ptr m_right;
   };
 
   class Boolean final : public Base
   {
   public:
-    explicit Boolean(const std::optional<Position>& position, bool value)
+    const bool value;
+
+    explicit Boolean(const std::optional<Position>& position, bool value_)
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Boolean;
     }
 
-    inline bool value() const
-    {
-      return m_value;
-    }
-
     inline std::u32string ToString() const override
     {
-      return m_value ? U"true" : U"false";
+      return value ? U"true" : U"false";
     }
-
-  private:
-    const bool m_value;
   };
 
   class Call final : public Base
   {
   public:
+    const ptr expression;
+    const std::vector<ptr> arguments;
+    const bool conditional;
+
     explicit Call(
       const std::optional<Position>& position,
-      const ptr& expression,
-      const std::vector<ptr>& arguments = {},
-      bool conditional = false
+      const ptr& expression_,
+      const std::vector<ptr>& arguments_ = {},
+      bool conditional_ = false
     )
       : Base(position)
-      , m_expression(expression)
-      , m_arguments(arguments)
-      , m_conditional(conditional) {}
+      , expression(expression_)
+      , arguments(arguments_)
+      , conditional(conditional_) {}
 
     inline Kind kind() const override
     {
       return Kind::Call;
     }
 
-    inline const ptr& expression() const
-    {
-      return m_expression;
-    }
-
-    inline const std::vector<ptr>& arguments() const
-    {
-      return m_arguments;
-    }
-
-    inline bool conditional() const
-    {
-      return m_conditional;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_expression;
-    const std::vector<ptr> m_arguments;
-    const bool m_conditional;
   };
 
   class Decrement final : public Base
   {
   public:
+    const ptr variable;
+    const bool pre;
+
     explicit Decrement(
       const std::optional<Position>& position,
-      const ptr& variable,
-      bool pre
+      const ptr& variable_,
+      bool pre_
     )
       : Base(position)
-      , m_variable(variable)
-      , m_pre(pre) {}
+      , variable(variable_)
+      , pre(pre_) {}
 
     inline Kind kind() const override
     {
       return Kind::Decrement;
     }
 
-    inline const ptr& variable() const
-    {
-      return m_variable;
-    }
-
-    inline bool pre() const
-    {
-      return m_pre;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_variable;
-    const bool m_pre;
   };
 
   class Float final : public Base
   {
   public:
-    explicit Float(const std::optional<Position>& position, double value)
+    const double value;
+
+    explicit Float(const std::optional<Position>& position, double value_)
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Float;
     }
 
-    inline double value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const double m_value;
   };
 
   class Function final : public Base
   {
   public:
+    const std::vector<Parameter> parameters;
+    const type::ptr return_type;
+    const statement::ptr body;
+
     explicit Function(
       const std::optional<Position>& position,
-      const std::vector<Parameter>& parameters,
-      const type::ptr& return_type,
-      const statement::ptr& body
+      const std::vector<Parameter>& parameters_,
+      const type::ptr& return_type_,
+      const statement::ptr& body_
     )
       : Base(position)
-      , m_parameters(parameters)
-      , m_return_type(return_type)
-      , m_body(body) {}
+      , parameters(parameters_)
+      , return_type(return_type_)
+      , body(body_) {}
 
     inline Kind kind() const override
     {
       return Kind::Function;
     }
 
-    inline const std::vector<Parameter>& parameters() const
-    {
-      return m_parameters;
-    }
-
-    inline const type::ptr& return_type() const
-    {
-      return m_return_type;
-    }
-
-    inline const statement::ptr& body() const
-    {
-      return m_body;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::vector<Parameter> m_parameters;
-    const type::ptr m_return_type;
-    const statement::ptr m_body;
   };
 
   class Id final : public Base
   {
   public:
+    const std::u32string identifier;
+
     explicit Id(
       const std::optional<Position>& position,
-      const std::u32string& identifier
+      const std::u32string& identifier_
     )
       : Base(position)
-      , m_identifier(identifier) {}
+      , identifier(identifier_) {}
 
     inline Kind kind() const override
     {
       return Kind::Id;
-    }
-
-    inline const std::u32string& identifier() const
-    {
-      return m_identifier;
     }
 
     inline bool IsAssignable() const override
@@ -421,68 +331,48 @@ namespace snek::parser::expression
 
     inline std::u32string ToString() const override
     {
-      return m_identifier;
+      return identifier;
     }
-
-  private:
-    const std::u32string m_identifier;
   };
 
   class Increment final : public Base
   {
   public:
+    const ptr variable;
+    const bool pre;
+
     explicit Increment(
       const std::optional<Position>& position,
-      const ptr& variable,
-      bool pre
+      const ptr& variable_,
+      bool pre_
     )
       : Base(position)
-      , m_variable(variable)
-      , m_pre(pre) {}
+      , variable(variable_)
+      , pre(pre_) {}
 
     inline Kind kind() const override
     {
       return Kind::Increment;
     }
 
-    inline const ptr& variable() const
-    {
-      return m_variable;
-    }
-
-    inline bool pre() const
-    {
-      return m_pre;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_variable;
-    const bool m_pre;
   };
 
   class Int final : public Base
   {
   public:
-    explicit Int(const std::optional<Position>& position, std::int64_t value)
+    const std::int64_t value;
+
+    explicit Int(const std::optional<Position>& position, std::int64_t value_)
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Int;
     }
 
-    inline std::int64_t value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::int64_t m_value;
   };
 
   class List final : public Base
@@ -490,21 +380,18 @@ namespace snek::parser::expression
   public:
     using container_type = std::vector<element::ptr>;
 
+    const container_type elements;
+
     explicit List(
       const std::optional<Position>& position,
-      const container_type& elements
+      const container_type& elements_
     )
       : Base(position)
-      , m_elements(elements) {}
+      , elements(elements_) {}
 
     inline Kind kind() const override
     {
       return Kind::List;
-    }
-
-    inline const container_type& elements() const
-    {
-      return m_elements;
     }
 
     inline bool IsAssignable() const override
@@ -513,9 +400,6 @@ namespace snek::parser::expression
     }
 
     std::u32string ToString() const override;
-
-  private:
-    const container_type m_elements;
   };
 
   class Null final : public Base
@@ -538,43 +422,27 @@ namespace snek::parser::expression
   class Property final : public Base
   {
   public:
+    const ptr expression;
+    const std::u32string name;
+    const bool conditional;
+
     explicit Property(
       const std::optional<Position>& position,
-      const ptr& expression,
-      const std::u32string& name,
-      bool conditional = false
+      const ptr& expression_,
+      const std::u32string& name_,
+      bool conditional_ = false
     )
       : Base(position)
-      , m_expression(expression)
-      , m_name(name)
-      , m_conditional(conditional) {}
+      , expression(expression_)
+      , name(name_)
+      , conditional(conditional_) {}
 
     inline Kind kind() const override
     {
       return Kind::Property;
     }
 
-    inline const ptr& expression() const
-    {
-      return m_expression;
-    }
-
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
-    inline bool conditional() const
-    {
-      return m_conditional;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_expression;
-    const std::u32string m_name;
-    const bool m_conditional;
   };
 
   class Record final : public Base
@@ -582,168 +450,118 @@ namespace snek::parser::expression
   public:
     using container_type = std::vector<field::ptr>;
 
+    const container_type fields;
+
     explicit Record(
       const std::optional<Position>& position,
-      const container_type& fields
+      const container_type& fields_
     )
       : Base(position)
-      , m_fields(fields) {}
+      , fields(fields_) {}
 
     inline Kind kind() const override
     {
       return Kind::Record;
     }
 
-    inline const container_type& fields() const
-    {
-      return m_fields;
-    }
-
     bool IsAssignable() const override;
 
     std::u32string ToString() const override;
-
-  private:
-    const container_type m_fields;
   };
 
   class Spread final : public Base
   {
   public:
+    const ptr expression;
+
     explicit Spread(
       const std::optional<Position>& position,
-      const ptr& expression
+      const ptr& expression_
     )
       : Base(position)
-      , m_expression(expression) {}
+      , expression(expression_) {}
 
     inline Kind kind() const override
     {
       return Kind::Spread;
     }
 
-    inline const ptr& expression() const
-    {
-      return m_expression;
-    }
-
     inline std::u32string ToString() const override
     {
-      return U"..." + m_expression->ToString();
+      return U"..." + expression->ToString();
     }
-
-  private:
-    const ptr m_expression;
   };
 
   class String final : public Base
   {
   public:
+    const std::u32string value;
+
     explicit String(
       const std::optional<Position>& position,
-      const std::u32string& value
+      const std::u32string& value_
     )
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::String;
     }
 
-    inline const std::u32string& value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::u32string m_value;
   };
 
   class Ternary final : public Base
   {
   public:
+    const ptr condition;
+    const ptr then_expression;
+    const ptr else_expression;
+
     explicit Ternary(
       const std::optional<Position>& position,
-      const ptr& condition,
-      const ptr& then_expression,
-      const ptr& else_expression
+      const ptr& condition_,
+      const ptr& then_expression_,
+      const ptr& else_expression_
     )
       : Base(position)
-      , m_condition(condition)
-      , m_then_expression(then_expression)
-      , m_else_expression(else_expression) {}
+      , condition(condition_)
+      , then_expression(then_expression_)
+      , else_expression(else_expression_) {}
 
     inline Kind kind() const override
     {
       return Kind::Ternary;
     }
 
-    inline const ptr& condition() const
-    {
-      return m_condition;
-    }
-
-    inline const ptr& then_expression() const
-    {
-      return m_then_expression;
-    }
-
-    inline const ptr& else_expression() const
-    {
-      return m_else_expression;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_condition;
-    const ptr m_then_expression;
-    const ptr m_else_expression;
   };
 
   class Subscript final : public Base
   {
   public:
+    const ptr expression;
+    const ptr index;
+    const bool conditional;
+
     explicit Subscript(
       const std::optional<Position>& position,
-      const ptr& expression,
-      const ptr& index,
-      bool conditional
+      const ptr& expression_,
+      const ptr& index_,
+      bool conditional_
     )
       : Base(position)
-      , m_expression(expression)
-      , m_index(index)
-      , m_conditional(conditional) {}
+      , expression(expression_)
+      , index(index_)
+      , conditional(conditional_) {}
 
     inline Kind kind() const override
     {
       return Kind::Subscript;
     }
 
-    inline const ptr& expression() const
-    {
-      return m_expression;
-    }
-
-    inline const ptr& index() const
-    {
-      return m_index;
-    }
-
-    inline bool conditional() const
-    {
-      return m_conditional;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const ptr m_expression;
-    const ptr m_index;
-    const bool m_conditional;
   };
 
   class Unary final : public Base
@@ -759,36 +577,25 @@ namespace snek::parser::expression
 
     static std::u32string GetMethodName(Operator op);
 
+    const Operator op;
+    const ptr operand;
+
     explicit Unary(
       const std::optional<Position>& position,
-      Operator op,
-      const ptr& operand
+      Operator op_,
+      const ptr& operand_
     )
       : Base(position)
-      , m_op(op)
-      , m_operand(operand) {}
+      , op(op_)
+      , operand(operand_) {}
 
     inline Kind kind() const override
     {
       return Kind::Unary;
     }
 
-    inline Operator op() const
-    {
-      return m_op;
-    }
-
-    inline const ptr& operand() const
-    {
-      return m_operand;
-    }
-
     static std::u32string ToString(Operator op);
 
     std::u32string ToString() const override;
-
-  private:
-    const Operator m_op;
-    const ptr m_operand;
   };
 }

--- a/parser/include/snek/parser/field.hpp
+++ b/parser/include/snek/parser/field.hpp
@@ -77,170 +77,115 @@ namespace snek::parser::field
   class Computed final : public Base
   {
   public:
+    const expression::ptr key;
+    const expression::ptr value;
+
     explicit Computed(
       const std::optional<Position>& position,
-      const expression::ptr& key,
-      const expression::ptr& value
+      const expression::ptr& key_,
+      const expression::ptr& value_
     )
       : Base(position)
-      , m_key(key)
-      , m_value(value) {}
+      , key(key_)
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Computed;
     }
 
-    inline const expression::ptr& key() const
-    {
-      return m_key;
-    }
-
-    inline const expression::ptr& value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const expression::ptr m_key;
-    const expression::ptr m_value;
   };
 
   class Function final : public Base
   {
   public:
+    const std::u32string name;
+    const std::vector<Parameter> parameters;
+    const type::ptr return_type;
+    const statement::ptr body;
+
     explicit Function(
       const std::optional<Position>& position,
-      const std::u32string& name,
-      const std::vector<Parameter>& parameters,
-      const type::ptr& return_type,
-      const statement::ptr& body
+      const std::u32string& name_,
+      const std::vector<Parameter>& parameters_,
+      const type::ptr& return_type_,
+      const statement::ptr& body_
     )
       : Base(position)
-      , m_name(name)
-      , m_parameters(parameters)
-      , m_return_type(return_type)
-      , m_body(body) {}
+      , name(name_)
+      , parameters(parameters_)
+      , return_type(return_type_)
+      , body(body_) {}
 
     inline Kind kind() const override
     {
       return Kind::Function;
     }
 
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
-    inline const std::vector<Parameter>& parameters() const
-    {
-      return m_parameters;
-    }
-
-    inline const type::ptr& return_type() const
-    {
-      return m_return_type;
-    }
-
-    inline const statement::ptr& body() const
-    {
-      return m_body;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::u32string m_name;
-    const std::vector<Parameter> m_parameters;
-    const type::ptr m_return_type;
-    const statement::ptr m_body;
   };
 
   class Named final : public Base
   {
   public:
+    const std::u32string name;
+    const expression::ptr value;
+
     explicit Named(
       const std::optional<Position>& position,
-      const std::u32string& name,
-      const expression::ptr& value
+      const std::u32string& name_,
+      const expression::ptr& value_
     )
       : Base(position)
-      , m_name(name)
-      , m_value(value) {}
+      , name(name_)
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Named;
     }
 
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
-    inline const expression::ptr& value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::u32string m_name;
-    const expression::ptr m_value;
   };
 
   class Shorthand final : public Base
   {
   public:
+    const std::u32string name;
+
     explicit Shorthand(
       const std::optional<Position>& position,
-      const std::u32string& name
+      const std::u32string& name_
     )
       : Base(position)
-      , m_name(name) {}
+      , name(name_) {}
 
     inline Kind kind() const override
     {
       return Kind::Shorthand;
     }
 
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::u32string m_name;
   };
 
   class Spread final : public Base
   {
   public:
+    const expression::ptr expression;
+
     explicit Spread(
       const std::optional<Position>& position,
-      const expression::ptr& expression
+      const expression::ptr& expression_
     )
       : Base(position)
-      , m_expression(expression) {}
+      , expression(expression_) {}
 
     inline Kind kind() const override
     {
       return Kind::Spread;
     }
 
-    inline const expression::ptr& expression() const
-    {
-      return m_expression;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const expression::ptr m_expression;
   };
 }

--- a/parser/include/snek/parser/import.hpp
+++ b/parser/include/snek/parser/import.hpp
@@ -42,22 +42,16 @@ namespace snek::parser::import
   public:
     DISALLOW_COPY_AND_ASSIGN(Base);
 
+    const std::optional<std::u32string> alias;
+
     explicit Base(
       const std::optional<Position>& position,
-      const std::optional<std::u32string>& alias = std::nullopt
+      const std::optional<std::u32string>& alias_ = std::nullopt
     )
       : Node(position)
-      , m_alias(alias) {}
+      , alias(alias_) {}
 
     virtual Kind kind() const = 0;
-
-    inline const std::optional<std::u32string>& alias() const
-    {
-      return m_alias;
-    }
-
-  private:
-    const std::optional<std::u32string> m_alias;
   };
 
   using ptr = std::shared_ptr<Base>;
@@ -67,38 +61,32 @@ namespace snek::parser::import
   class Named final : public Base
   {
   public:
+    const std::u32string name;
+
     explicit Named(
       const std::optional<Position>& position,
-      const std::u32string name,
+      const std::u32string name_,
       const std::optional<std::u32string>& alias = std::nullopt
     )
       : Base(position, alias)
-      , m_name(name) {}
+      , name(name_) {}
 
     inline Kind kind() const override
     {
       return Kind::Named;
     }
 
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
     inline std::u32string ToString() const override
     {
-      std::u32string result(name());
+      auto result = name;
 
-      if (const auto al = alias())
+      if (alias)
       {
-        result.append(U" as ").append(*al);
+        result.append(U" as ").append(*alias);
       }
 
       return result;
     }
-
-  private:
-    const std::u32string m_name;
   };
 
   class Star final : public Base
@@ -119,9 +107,9 @@ namespace snek::parser::import
     {
       std::u32string result(U"*");
 
-      if (const auto al = alias())
+      if (alias)
       {
-        result.append(U" as ").append(*al);
+        result.append(U" as ").append(*alias);
       }
 
       return result;

--- a/parser/include/snek/parser/lexer.hpp
+++ b/parser/include/snek/parser/lexer.hpp
@@ -110,7 +110,7 @@ namespace snek::parser
     {
       return m_token_queue.empty()
         ? m_input->position()
-        : m_token_queue.front().position();
+        : m_token_queue.front().position;
     }
 
     Token ReadToken();

--- a/parser/include/snek/parser/node.hpp
+++ b/parser/include/snek/parser/node.hpp
@@ -34,17 +34,11 @@ namespace snek::parser
   class Node
   {
   public:
-    Node(const std::optional<Position>& position)
-      : m_position(position) {}
+    std::optional<Position> position;
 
-    inline const std::optional<Position>& position() const
-    {
-      return m_position;
-    }
+    Node(const std::optional<Position>& position_)
+      : position(position_) {}
 
     virtual std::u32string ToString() const = 0;
-
-  private:
-    std::optional<Position> m_position;
   };
 }

--- a/parser/include/snek/parser/parameter.hpp
+++ b/parser/include/snek/parser/parameter.hpp
@@ -49,8 +49,6 @@ namespace snek::parser
   class Parameter final : public Node
   {
   public:
-    DEFAULT_COPY_AND_ASSIGN(Parameter);
-
     static Parameter Parse(Lexer& lexer);
 
     static std::vector<Parameter> ParseList(
@@ -58,45 +56,24 @@ namespace snek::parser
       bool read_opening_parenthesis = true
     );
 
+    const std::u32string name;
+    const type::ptr type;
+    const expression::ptr default_value;
+    const bool rest;
+
     Parameter(
       const std::optional<Position>& position = std::nullopt,
-      const std::u32string& name = U"arg",
-      const type::ptr& type = nullptr,
-      const expression::ptr& default_value = nullptr,
-      bool rest = false
+      const std::u32string& name_ = U"arg",
+      const type::ptr& type_ = nullptr,
+      const expression::ptr& default_value_ = nullptr,
+      bool rest_ = false
     )
       : Node(position)
-      , m_name(name)
-      , m_type(type)
-      , m_default_value(default_value)
-      , m_rest(rest) {}
-
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
-    inline const type::ptr& type() const
-    {
-      return m_type;
-    }
-
-    inline const expression::ptr& default_value() const
-    {
-      return m_default_value;
-    }
-
-    inline bool rest() const
-    {
-      return m_rest;
-    }
+      , name(name_)
+      , type(type_)
+      , default_value(default_value_)
+      , rest(rest_) {}
 
     std::u32string ToString() const override;
-
-  private:
-    std::u32string m_name;
-    type::ptr m_type;
-    expression::ptr m_default_value;
-    bool m_rest;
   };
 }

--- a/parser/include/snek/parser/statement.hpp
+++ b/parser/include/snek/parser/statement.hpp
@@ -81,190 +81,125 @@ namespace snek::parser::statement
   public:
     using container_type = std::vector<ptr>;
 
+    const container_type statements;
+
     explicit Block(
       const std::optional<Position>& position,
-      const container_type& statements
+      const container_type& statements_
     )
       : Base(position)
-      , m_statements(statements) {}
+      , statements(statements_) {}
 
     inline Kind kind() const override
     {
       return Kind::Block;
     }
 
-    inline const container_type& statements() const
-    {
-      return m_statements;
-    }
-
     inline std::u32string ToString() const override
     {
       return U"...";
     }
-
-  private:
-    const container_type m_statements;
   };
 
   class DeclareType final : public Base
   {
   public:
+    const bool is_export;
+    const std::u32string name;
+    const type::ptr type;
+
     explicit DeclareType(
       const std::optional<Position>& position,
-      bool is_export,
-      const std::u32string& name,
-      const type::ptr& type
+      bool is_export_,
+      const std::u32string name_,
+      const type::ptr type_
     )
       : Base(position)
-      , m_exported(is_export)
-      , m_name(name)
-      , m_type(type) {}
+      , is_export(is_export_)
+      , name(name_)
+      , type(type_) {}
 
     inline Kind kind() const override
     {
       return Kind::DeclareType;
     }
 
-    inline bool exported() const
-    {
-      return m_exported;
-    }
-
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
-    inline const type::ptr& type() const
-    {
-      return m_type;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const bool m_exported;
-    const std::u32string m_name;
-    const type::ptr m_type;
   };
 
   class DeclareVar final : public Base
   {
   public:
+    const bool is_export;
+    const bool is_read_only;
+    const expression::ptr variable;
+    const expression::ptr value;
+
     explicit DeclareVar(
       const std::optional<Position>& position,
-      bool exported,
-      bool read_only,
-      const expression::ptr& variable,
-      const expression::ptr& value
+      bool is_export_,
+      bool is_read_only_,
+      const expression::ptr& variable_,
+      const expression::ptr& value_
     )
       : Base(position)
-      , m_exported(exported)
-      , m_read_only(read_only)
-      , m_variable(variable)
-      , m_value(value) {}
+      , is_export(is_export_)
+      , is_read_only(is_read_only_)
+      , variable(variable_)
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::DeclareVar;
     }
 
-    inline bool exported() const
-    {
-      return m_exported;
-    }
-
-    inline bool read_only() const
-    {
-      return m_read_only;
-    }
-
-    inline const expression::ptr& variable() const
-    {
-      return m_variable;
-    }
-
-    inline const expression::ptr& value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const bool m_exported;
-    const bool m_read_only;
-    const expression::ptr m_variable;
-    const expression::ptr m_value;
   };
 
   class Expression final : public Base
   {
   public:
-    explicit Expression(const expression::ptr& expression)
-      : Base(expression->position())
-      , m_expression(expression) {}
+    const expression::ptr expression;
+
+    explicit Expression(const expression::ptr& expression_)
+      : Base(expression_->position)
+      , expression(expression_) {}
 
     inline Kind kind() const override
     {
       return Kind::Expression;
     }
 
-    inline const expression::ptr& expression() const
-    {
-      return m_expression;
-    }
-
     inline std::u32string ToString() const override
     {
-      return m_expression->ToString().append(1, U';');
+      return expression->ToString();
     }
-
-  private:
-    const expression::ptr m_expression;
   };
 
   class If final : public Base
   {
   public:
+    const expression::ptr condition;
+    const ptr then_statement;
+    const ptr else_statement;
+
     explicit If(
       const std::optional<Position>& position,
-      const expression::ptr& condition,
-      const ptr& then_statement,
-      const ptr& else_statement = nullptr
+      const expression::ptr& condition_,
+      const ptr& then_statement_,
+      const ptr& else_statement_ = nullptr
     )
       : Base(position)
-      , m_condition(condition)
-      , m_then_statement(then_statement)
-      , m_else_statement(else_statement) {}
+      , condition(condition_)
+      , then_statement(then_statement_)
+      , else_statement(else_statement_) {}
 
     inline Kind kind() const override
     {
       return Kind::If;
     }
 
-    inline const expression::ptr& condition() const
-    {
-      return m_condition;
-    }
-
-    inline const ptr& then_statement() const
-    {
-      return m_then_statement;
-    }
-
-    inline const ptr& else_statement() const
-    {
-      return m_else_statement;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const expression::ptr m_condition;
-    const ptr m_then_statement;
-    const ptr m_else_statement;
   };
 
   class Import final : public Base
@@ -272,104 +207,71 @@ namespace snek::parser::statement
   public:
     using container_type = std::vector<import::ptr>;
 
+    const container_type specifiers;
+    const std::u32string path;
+
     explicit Import(
       const std::optional<Position>& position,
-      const container_type& specifiers,
-      const std::u32string& path
+      const container_type& specifiers_,
+      const std::u32string& path_
     )
       : Base(position)
-      , m_specifiers(specifiers)
-      , m_path(path) {}
+      , specifiers(specifiers_)
+      , path(path_) {}
 
     inline Kind kind() const override
     {
       return Kind::Import;
     }
 
-    inline const container_type& specifiers() const
-    {
-      return m_specifiers;
-    }
-
-    inline const std::u32string& path() const
-    {
-      return m_path;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const container_type m_specifiers;
-    const std::u32string m_path;
   };
 
   class Jump final : public Base
   {
   public:
+    const JumpKind jump_kind;
+    const expression::ptr value;
+
     explicit Jump(
       const std::optional<Position>& position,
-      JumpKind jump_kind,
-      const expression::ptr& value = nullptr
+      JumpKind jump_kind_,
+      const expression::ptr& value_ = nullptr
     )
       : Base(position)
-      , m_jump_kind(jump_kind)
-      , m_value(value) {}
+      , jump_kind(jump_kind_)
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Jump;
     }
 
-    inline JumpKind jump_kind() const
-    {
-      return m_jump_kind;
-    }
-
-    inline const expression::ptr& value() const
-    {
-      return m_value;
-    }
-
     static std::u32string ToString(JumpKind kind);
 
     std::u32string ToString() const override;
-
-  private:
-    const JumpKind m_jump_kind;
-    const expression::ptr m_value;
   };
 
   class While final : public Base
   {
   public:
+    const expression::ptr condition;
+    const ptr body;
+
     explicit While(
       const std::optional<Position>& position,
-      const expression::ptr& condition,
-      const ptr& body
+      const expression::ptr& condition_,
+      const ptr& body_
     )
       : Base(position)
-      , m_condition(condition)
-      , m_body(body) {}
+      , condition(condition_)
+      , body(body_) {}
 
     inline Kind kind() const override
     {
       return Kind::While;
     }
 
-    inline const expression::ptr& condition() const
-    {
-      return m_condition;
-    }
-
-    inline const ptr& body() const
-    {
-      return m_body;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const expression::ptr m_condition;
-    const ptr m_body;
   };
 }

--- a/parser/include/snek/parser/token.hpp
+++ b/parser/include/snek/parser/token.hpp
@@ -128,31 +128,20 @@ namespace snek::parser
       KeywordWhile,
     };
 
+    Kind kind;
+    std::optional<std::u32string> text;
+
     Token(
       const std::optional<Position>& position = std::nullopt,
-      Kind kind = Kind::Eof,
-      const std::optional<std::u32string>& text = std::nullopt
+      Kind kind_ = Kind::Eof,
+      const std::optional<std::u32string>& text_ = std::nullopt
     )
       : Node(position)
-      , m_kind(kind)
-      , m_text(text) {}
-
-    inline Kind kind() const
-    {
-      return m_kind;
-    }
-
-    inline const std::optional<std::u32string>& text() const
-    {
-      return m_text;
-    }
+      , kind(kind_)
+      , text(text_) {}
 
     static std::u32string ToString(Kind kind);
 
     std::u32string ToString() const override;
-
-  private:
-    Kind m_kind;
-    std::optional<std::u32string> m_text;
   };
 }

--- a/parser/include/snek/parser/type.hpp
+++ b/parser/include/snek/parser/type.hpp
@@ -63,90 +63,70 @@ namespace snek::parser::type
   public:
     using value_type = bool;
 
-    explicit Boolean(const std::optional<Position>& position, value_type value)
+    const value_type value;
+
+    explicit Boolean(
+      const std::optional<Position>& position,
+      value_type value_
+    )
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::Boolean;
     }
 
-    inline value_type value() const
-    {
-      return m_value;
-    }
-
     inline std::u32string ToString() const override
     {
-      return m_value ? U"true" : U"false";
+      return value ? U"true" : U"false";
     }
-
-  private:
-    const value_type m_value;
   };
 
   class Function final : public Base
   {
   public:
+    const std::vector<Parameter> parameters;
+    const ptr return_type;
+
     explicit Function(
       const std::optional<Position>& position,
-      const std::vector<Parameter>& parameters,
-      const ptr& return_type
+      const std::vector<Parameter>& parameters_,
+      const ptr& return_type_
     )
       : Base(position)
-      , m_parameters(parameters)
-      , m_return_type(return_type) {}
+      , parameters(parameters_)
+      , return_type(return_type_) {}
 
     inline Kind kind() const override
     {
       return Kind::Function;
     }
 
-    inline const std::vector<Parameter>& parameters() const
-    {
-      return m_parameters;
-    }
-
-    inline const ptr& return_type() const
-    {
-      return m_return_type;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const std::vector<Parameter> m_parameters;
-    const ptr m_return_type;
   };
 
   class List final : public Base
   {
   public:
+    const ptr element_type;
+
     explicit List(
       const std::optional<Position>& position,
-      const ptr& element_type
+      const ptr& element_type_
     )
       : Base(position)
-      , m_element_type(element_type) {}
+      , element_type(element_type_) {}
 
     inline Kind kind() const override
     {
       return Kind::List;
     }
 
-    inline const ptr& element_type() const
-    {
-      return m_element_type;
-    }
-
     inline std::u32string ToString() const override
     {
-      return m_element_type->ToString() + U"[]";
+      return element_type->ToString() + U"[]";
     }
-
-  private:
-    const ptr m_element_type;
   };
 
   class Multiple final : public Base
@@ -162,64 +142,47 @@ namespace snek::parser::type
       Union,
     };
 
+    const MultipleKind multiple_kind;
+    const container_type types;
+
     explicit Multiple(
       const std::optional<Position>& position,
-      MultipleKind multiple_kind,
-      const container_type& types
+      MultipleKind multiple_kind_,
+      const container_type& types_
     )
       : Base(position)
-      , m_multiple_kind(multiple_kind)
-      , m_types(types) {}
+      , multiple_kind(multiple_kind_)
+      , types(types_) {}
 
     inline Kind kind() const override
     {
       return Kind::Multiple;
     }
 
-    inline MultipleKind multiple_kind() const
-    {
-      return m_multiple_kind;
-    }
-
-    inline const container_type& types() const
-    {
-      return m_types;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const MultipleKind m_multiple_kind;
-    const container_type m_types;
   };
 
   class Named final : public Base
   {
   public:
+    const std::u32string name;
+
     explicit Named(
       const std::optional<Position>& position,
-      const std::u32string& name
+      const std::u32string& name_
     )
       : Base(position)
-      , m_name(name) {}
+      , name(name_) {}
 
     inline Kind kind() const override
     {
       return Kind::Named;
     }
 
-    inline const std::u32string& name() const
-    {
-      return m_name;
-    }
-
     inline std::u32string ToString() const override
     {
-      return m_name;
+      return name;
     }
-
-  private:
-    const std::u32string m_name;
   };
 
   class Null final : public Base
@@ -246,27 +209,21 @@ namespace snek::parser::type
     using mapped_type = ptr;
     using container_type = std::unordered_map<key_type, mapped_type>;
 
+    const container_type fields;
+
     explicit Record(
       const std::optional<Position>& position,
-      const container_type& fields
+      const container_type& fields_
     )
       : Base(position)
-      , m_fields(fields) {}
+      , fields(fields_) {}
 
     inline Kind kind() const override
     {
       return Kind::Record;
     }
 
-    inline const container_type& fields() const
-    {
-      return m_fields;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const container_type m_fields;
   };
 
   class String final : public Base
@@ -275,26 +232,20 @@ namespace snek::parser::type
     using value_type = std::u32string;
     using const_reference = const value_type&;
 
+    const value_type value;
+
     explicit String(
       const std::optional<Position>& position,
-      const_reference value
+      const_reference value_
     )
       : Base(position)
-      , m_value(value) {}
+      , value(value_) {}
 
     inline Kind kind() const override
     {
       return Kind::String;
     }
 
-    inline const_reference value() const
-    {
-      return m_value;
-    }
-
     std::u32string ToString() const override;
-
-  private:
-    const value_type m_value;
   };
 }

--- a/parser/src/element.cpp
+++ b/parser/src/element.cpp
@@ -35,7 +35,7 @@ namespace snek::parser::element
     const auto token = lexer.ReadToken();
     Kind kind = Kind::Value;
 
-    if (token.kind() == Token::Kind::Spread)
+    if (token.kind == Token::Kind::Spread)
     {
       kind = Kind::Spread;
     } else {
@@ -43,7 +43,7 @@ namespace snek::parser::element
     }
 
     return std::make_shared<Base>(
-      token.position(),
+      token.position,
       kind,
       expression::Parse(lexer)
     );
@@ -52,8 +52,8 @@ namespace snek::parser::element
   std::u32string
   Base::ToString() const
   {
-    return m_kind == Kind::Spread
-      ? U"..." + m_expression->ToString()
-      : m_expression->ToString();
+    return kind == Kind::Spread
+      ? U"..." + expression->ToString()
+      : expression->ToString();
   }
 }

--- a/parser/src/field.cpp
+++ b/parser/src/field.cpp
@@ -68,8 +68,8 @@ namespace snek::parser::field
       }
 
       return std::make_shared<Function>(
-        token.position(),
-        *token.text(),
+        token.position,
+        *token.text,
         parameters,
         return_type,
         statement::ParseFunctionBody(lexer)
@@ -79,12 +79,12 @@ namespace snek::parser::field
     // key such as string or number.
     else if (!lexer.PeekReadToken(Token::Kind::Colon))
     {
-      return std::make_shared<Shorthand>(token.position(), *token.text());
+      return std::make_shared<Shorthand>(token.position, *token.text);
     }
 
     return std::make_shared<Named>(
-      token.position(),
-      *token.text(),
+      token.position,
+      *token.text,
       expression::Parse(lexer)
     );
   }
@@ -94,13 +94,13 @@ namespace snek::parser::field
   {
     const auto token = lexer.ReadToken();
 
-    switch (token.kind())
+    switch (token.kind)
     {
       case Token::Kind::LeftBracket:
-        return ParseComputed(token.position(), lexer);
+        return ParseComputed(token.position, lexer);
 
       case Token::Kind::Spread:
-        return ParseSpread(token.position(), lexer);
+        return ParseSpread(token.position, lexer);
 
       case Token::Kind::Id:
       case Token::Kind::String:
@@ -121,27 +121,28 @@ namespace snek::parser::field
   std::u32string
   Computed::ToString() const
   {
-    return U'[' + m_key->ToString() + U"]: " + m_value->ToString();
+    return U'[' + key->ToString() + U"]: " + value->ToString();
   }
 
   std::u32string
   Function::ToString() const
   {
-    std::u32string result(m_name);
+    std::u32string result(name);
+    const auto size = parameters.size();
 
     result.append(1, U'(');
-    for (std::size_t i = 0; i < m_parameters.size(); ++i)
+    for (std::size_t i = 0; i < size; ++i)
     {
       if (i > 0)
       {
         result.append(U", ");
       }
-      result.append(m_parameters[i].ToString());
+      result.append(parameters[i].ToString());
     }
     result.append(1, U')');
-    if (m_return_type)
+    if (return_type)
     {
-      result.append(U" -> ").append(m_return_type->ToString());
+      result.append(U" -> ").append(return_type->ToString());
     }
 
     return result;
@@ -150,23 +151,23 @@ namespace snek::parser::field
   std::u32string
   Named::ToString() const
   {
-    if (utils::IsId(m_name))
+    if (utils::IsId(name))
     {
-      return m_name + U": " + m_value->ToString();
+      return name + U": " + value->ToString();
     }
 
-    return utils::ToJsonString(m_name) + U": " + m_value->ToString();
+    return utils::ToJsonString(name) + U": " + value->ToString();
   }
 
   std::u32string
   Shorthand::ToString() const
   {
-    return utils::IsId(m_name) ? m_name : utils::ToJsonString(m_name);
+    return utils::IsId(name) ? name : utils::ToJsonString(name);
   }
 
   std::u32string
   Spread::ToString() const
   {
-    return U"..." + m_expression->ToString();
+    return U"..." + expression->ToString();
   }
 }

--- a/parser/src/lexer.cpp
+++ b/parser/src/lexer.cpp
@@ -278,10 +278,10 @@ namespace snek::parser
   {
     const auto token = ReadToken();
 
-    if (token.kind() != expected)
+    if (token.kind != expected)
     {
       throw SyntaxError{
-        token.position(),
+        token.position,
         U"Unexpected " +
         token.ToString() +
         U"; Missing " +
@@ -294,7 +294,7 @@ namespace snek::parser
   void
   Lexer::UnreadToken(const Token& token)
   {
-    if (token.kind() != Token::Kind::Eof)
+    if (token.kind != Token::Kind::Eof)
     {
       m_token_queue.push_front(token);
     }
@@ -325,7 +325,7 @@ namespace snek::parser
 
     UnreadToken(token);
 
-    return token.kind() == expected;
+    return token.kind == expected;
   }
 
   bool
@@ -337,7 +337,7 @@ namespace snek::parser
     m_token_queue.push_front(token);
     m_token_queue.push_front(skip);
 
-    return token.kind() == expected;
+    return token.kind == expected;
   }
 
   bool
@@ -345,7 +345,7 @@ namespace snek::parser
   {
     const auto token = ReadToken();
 
-    if (token.kind() != expected)
+    if (token.kind != expected)
     {
       UnreadToken(token);
 
@@ -360,17 +360,17 @@ namespace snek::parser
   {
     const auto token = ReadToken();
 
-    if (token.kind() != Token::Kind::Id)
+    if (token.kind != Token::Kind::Id)
     {
       throw SyntaxError{
-        token.position(),
+        token.position,
         U"Unexpected " +
-        Token::ToString(token.kind()) +
+        Token::ToString(token.kind) +
         U"; Missing identifier."
       };
     }
 
-    return *token.text();
+    return *token.text;
   }
 
   std::u32string
@@ -378,17 +378,17 @@ namespace snek::parser
   {
     const auto token = ReadToken();
 
-    if (token.kind() != Token::Kind::String)
+    if (token.kind != Token::Kind::String)
     {
       throw SyntaxError{
-        token.position(),
+        token.position,
         U"Unexpected " +
-        Token::ToString(token.kind()) +
+        Token::ToString(token.kind) +
         U"; Missing string."
       };
     }
 
-    return *token.text();
+    return *token.text;
   }
 
   void

--- a/parser/src/parameter.cpp
+++ b/parser/src/parameter.cpp
@@ -83,7 +83,7 @@ namespace snek::parser
         };
       }
       lexer.PeekReadToken(Token::Kind::Comma);
-      if (parameter.rest())
+      if (parameter.rest)
       {
         lexer.ReadToken(Token::Kind::RightParen);
         break;
@@ -98,18 +98,18 @@ namespace snek::parser
   {
     std::u32string result;
 
-    if (m_rest)
+    if (rest)
     {
       result.append(U"...");
     }
-    result.append(m_name);
-    if (m_type)
+    result.append(name);
+    if (type)
     {
-      result.append(U": ").append(m_type->ToString());
+      result.append(U": ").append(type->ToString());
     }
-    if (m_default_value)
+    if (default_value)
     {
-      result.append(U" = ").append(m_default_value->ToString());
+      result.append(U" = ").append(default_value->ToString());
     }
 
     return result;

--- a/parser/src/token.cpp
+++ b/parser/src/token.cpp
@@ -273,11 +273,11 @@ namespace snek::parser
   std::u32string
   Token::ToString() const
   {
-    if (m_text && m_kind != Kind::String)
+    if (text && kind != Kind::String)
     {
-      return std::u32string(1, U'`').append(*m_text).append(1, U'\'');
+      return std::u32string(1, U'`').append(*text).append(1, U'\'');
     }
 
-    return ToString(m_kind);
+    return ToString(kind);
   }
 }

--- a/parser/src/type.cpp
+++ b/parser/src/type.cpp
@@ -39,14 +39,14 @@ namespace snek::parser::type
 
     types.push_back(first_type);
     types.push_back(Parse(lexer));
-    while (lexer.PeekReadToken(token.kind()))
+    while (lexer.PeekReadToken(token.kind))
     {
       types.push_back(Parse(lexer));
     }
 
     return std::make_shared<Multiple>(
-      token.position(),
-      token.kind() == Token::Kind::BitwiseAnd
+      token.position,
+      token.kind == Token::Kind::BitwiseAnd
         ? Multiple::MultipleKind::Intersection
         : Multiple::MultipleKind::Union,
       types
@@ -127,7 +127,7 @@ namespace snek::parser::type
       [&]() -> void
       {
         const auto name = lexer.PeekToken(Token::Kind::String)
-          ? *lexer.ReadToken().text()
+          ? *lexer.ReadToken().text
           : lexer.ReadId();
 
         lexer.ReadToken(Token::Kind::Colon);
@@ -169,49 +169,49 @@ namespace snek::parser::type
     const auto token = lexer.ReadToken();
     ptr type;
 
-    switch (token.kind())
+    switch (token.kind)
     {
       case Token::Kind::Eof:
         throw SyntaxError{
-          token.position(),
+          token.position,
           U"Unexpected end of input; Missing type."
         };
 
       case Token::Kind::Id:
-        type = std::make_shared<Named>(token.position(), *token.text());
+        type = std::make_shared<Named>(token.position, *token.text);
         break;
 
       case Token::Kind::KeywordNull:
-        type = std::make_shared<Null>(token.position());
+        type = std::make_shared<Null>(token.position);
         break;
 
       case Token::Kind::KeywordFalse:
       case Token::Kind::KeywordTrue:
         type = std::make_shared<Boolean>(
-          token.position(),
-          token.kind() == Token::Kind::KeywordTrue
+          token.position,
+          token.kind == Token::Kind::KeywordTrue
         );
         break;
 
       case Token::Kind::String:
-        type = std::make_shared<String>(token.position(), *token.text());
+        type = std::make_shared<String>(token.position, *token.text);
         break;
 
       case Token::Kind::LeftParen:
-        type = ParseFunction(lexer, token.position());
+        type = ParseFunction(lexer, token.position);
         break;
 
       case Token::Kind::LeftBrace:
-        type = ParseRecord(lexer, token.position());
+        type = ParseRecord(lexer, token.position);
         break;
 
       case Token::Kind::LeftBracket:
-        type = ParseTuple(lexer, token.position());
+        type = ParseTuple(lexer, token.position);
         break;
 
       default:
         throw SyntaxError{
-          token.position(),
+          token.position,
           U"Unexpected " + token.ToString() + U"; Missing type."
         };
     }
@@ -221,7 +221,7 @@ namespace snek::parser::type
       if (lexer.PeekReadToken(Token::Kind::LeftBracket))
       {
         lexer.ReadToken(Token::Kind::RightBracket);
-        type = std::make_shared<List>(type->position(), type);
+        type = std::make_shared<List>(type->position, type);
       }
       else if (
         lexer.PeekToken(Token::Kind::BitwiseAnd) ||
@@ -241,17 +241,18 @@ namespace snek::parser::type
   Function::ToString() const
   {
     std::u32string result(1, U'(');
+    const auto size = parameters.size();
 
-    for (std::size_t i = 0; i < m_parameters.size(); ++i)
+    for (std::size_t i = 0; i < size; ++i)
     {
       if (i > 0)
       {
         result.append(U", ");
       }
-      result.append(m_parameters[i].ToString());
+      result.append(parameters[i].ToString());
     }
     result.append(U") => ");
-    result.append(m_return_type ? m_return_type->ToString() : U"any");
+    result.append(return_type ? return_type->ToString() : U"any");
 
     return result;
   }
@@ -260,19 +261,19 @@ namespace snek::parser::type
   Multiple::ToString() const
   {
     const char32_t* separator =
-      m_multiple_kind == MultipleKind::Intersection
+      multiple_kind == MultipleKind::Intersection
       ? U" & "
-      : m_multiple_kind == MultipleKind::Union
+      : multiple_kind == MultipleKind::Union
       ? U" | "
       : U", ";
     std::u32string result;
     bool first = true;
 
-    if (m_multiple_kind == MultipleKind::Tuple)
+    if (multiple_kind == MultipleKind::Tuple)
     {
       result.append(1, U'[');
     }
-    for (const auto& type : m_types)
+    for (const auto& type : types)
     {
       if (first)
       {
@@ -282,7 +283,7 @@ namespace snek::parser::type
       }
       result.append(type->ToString());
     }
-    if (m_multiple_kind == MultipleKind::Tuple)
+    if (multiple_kind == MultipleKind::Tuple)
     {
       result.append(1, U']');
     }
@@ -296,7 +297,7 @@ namespace snek::parser::type
     bool first = true;
     std::u32string result(1, U'{');
 
-    for (const auto& field : m_fields)
+    for (const auto& field : fields)
     {
       if (first)
       {
@@ -321,6 +322,6 @@ namespace snek::parser::type
   std::u32string
   String::ToString() const
   {
-    return utils::ToJsonString(m_value);
+    return utils::ToJsonString(value);
   }
 }

--- a/parser/test/test_element.cpp
+++ b/parser/test/test_element.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Parse spread list element")
   Lexer lexer("...foo");
   const auto result = element::Parse(lexer);
 
-  REQUIRE(result->kind() == element::Kind::Spread);
+  REQUIRE(result->kind == element::Kind::Spread);
 }
 
 TEST_CASE("Parse ordinary list element")
@@ -42,5 +42,5 @@ TEST_CASE("Parse ordinary list element")
   Lexer lexer("foo");
   const auto result = element::Parse(lexer);
 
-  REQUIRE(result->kind() == element::Kind::Value);
+  REQUIRE(result->kind == element::Kind::Value);
 }

--- a/parser/test/test_import.cpp
+++ b/parser/test/test_import.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Parse ordinary import specifier")
   const auto result = import::ParseSpecifier(lexer);
 
   REQUIRE(result->kind() == import::Kind::Named);
-  REQUIRE(!result->alias());
+  REQUIRE(!result->alias);
 }
 
 TEST_CASE("Parse ordinary import specifier with alias")
@@ -44,7 +44,7 @@ TEST_CASE("Parse ordinary import specifier with alias")
   const auto result = import::ParseSpecifier(lexer);
 
   REQUIRE(result->kind() == import::Kind::Named);
-  REQUIRE(!result->alias()->compare(U"bar"));
+  REQUIRE(!result->alias->compare(U"bar"));
 }
 
 TEST_CASE("Parse star import specifier")
@@ -53,7 +53,7 @@ TEST_CASE("Parse star import specifier")
   const auto result = import::ParseSpecifier(lexer);
 
   REQUIRE(result->kind() == import::Kind::Star);
-  REQUIRE(!result->alias());
+  REQUIRE(!result->alias);
 }
 
 TEST_CASE("Parse star import specifier with alias")
@@ -62,5 +62,5 @@ TEST_CASE("Parse star import specifier with alias")
   const auto result = import::ParseSpecifier(lexer);
 
   REQUIRE(result->kind() == import::Kind::Star);
-  REQUIRE(!result->alias()->compare(U"foo"));
+  REQUIRE(!result->alias->compare(U"foo"));
 }

--- a/parser/test/test_parameter.cpp
+++ b/parser/test/test_parameter.cpp
@@ -37,10 +37,10 @@ TEST_CASE("Parse simple parameter")
   Lexer lexer("foo");
   const auto result = Parameter::Parse(lexer);
 
-  REQUIRE(!result.name().compare(U"foo"));
-  REQUIRE(!result.type());
-  REQUIRE(!result.default_value());
-  REQUIRE(!result.rest());
+  REQUIRE(!result.name.compare(U"foo"));
+  REQUIRE(!result.type);
+  REQUIRE(!result.default_value);
+  REQUIRE(!result.rest);
 }
 
 TEST_CASE("Parse rest parameter")
@@ -48,10 +48,10 @@ TEST_CASE("Parse rest parameter")
   Lexer lexer("...foo");
   const auto result = Parameter::Parse(lexer);
 
-  REQUIRE(!result.name().compare(U"foo"));
-  REQUIRE(!result.type());
-  REQUIRE(!result.default_value());
-  REQUIRE(result.rest());
+  REQUIRE(!result.name.compare(U"foo"));
+  REQUIRE(!result.type);
+  REQUIRE(!result.default_value);
+  REQUIRE(result.rest);
 }
 
 TEST_CASE("Parse typed parameter")
@@ -59,10 +59,10 @@ TEST_CASE("Parse typed parameter")
   Lexer lexer("foo: String");
   const auto result = Parameter::Parse(lexer);
 
-  REQUIRE(!result.name().compare(U"foo"));
-  REQUIRE(result.type()->kind() == type::Kind::Named);
-  REQUIRE(!result.default_value());
-  REQUIRE(!result.rest());
+  REQUIRE(!result.name.compare(U"foo"));
+  REQUIRE(result.type->kind() == type::Kind::Named);
+  REQUIRE(!result.default_value);
+  REQUIRE(!result.rest);
 }
 
 TEST_CASE("Parse parameter with default value")
@@ -70,10 +70,10 @@ TEST_CASE("Parse parameter with default value")
   Lexer lexer("foo = bar");
   const auto result = Parameter::Parse(lexer);
 
-  REQUIRE(!result.name().compare(U"foo"));
-  REQUIRE(!result.type());
-  REQUIRE(result.default_value()->kind() == expression::Kind::Id);
-  REQUIRE(!result.rest());
+  REQUIRE(!result.name.compare(U"foo"));
+  REQUIRE(!result.type);
+  REQUIRE(result.default_value->kind() == expression::Kind::Id);
+  REQUIRE(!result.rest);
 }
 
 TEST_CASE("Parse parameter list without opening parenthesis")
@@ -97,7 +97,7 @@ TEST_CASE("Parse parameter list with one parameter")
   const auto result = Parameter::ParseList(lexer);
 
   REQUIRE(result.size() == 1);
-  REQUIRE(!result[0].name().compare(U"foo"));
+  REQUIRE(!result[0].name.compare(U"foo"));
 }
 
 TEST_CASE("Parse parameter list with two parameters")
@@ -106,8 +106,8 @@ TEST_CASE("Parse parameter list with two parameters")
   const auto result = Parameter::ParseList(lexer);
 
   REQUIRE(result.size() == 2);
-  REQUIRE(!result[0].name().compare(U"foo"));
-  REQUIRE(!result[1].name().compare(U"bar"));
+  REQUIRE(!result[0].name.compare(U"foo"));
+  REQUIRE(!result[1].name.compare(U"bar"));
 }
 
 TEST_CASE("Parse parameter list with dangling comma")

--- a/parser/test/test_type.cpp
+++ b/parser/test/test_type.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Parse boolean type: true")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Boolean);
-  REQUIRE(As<type::Boolean>(result)->value());
+  REQUIRE(As<type::Boolean>(result)->value);
 }
 
 TEST_CASE("Parse boolean type: false")
@@ -75,7 +75,7 @@ TEST_CASE("Parse boolean type: false")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Boolean);
-  REQUIRE(!As<type::Boolean>(result)->value());
+  REQUIRE(!As<type::Boolean>(result)->value);
 }
 
 TEST_CASE("Parse string type")
@@ -84,7 +84,7 @@ TEST_CASE("Parse string type")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::String);
-  REQUIRE(!As<type::String>(result)->value().compare(U"foo"));
+  REQUIRE(!As<type::String>(result)->value.compare(U"foo"));
 }
 
 TEST_CASE("Parse function type")
@@ -95,8 +95,8 @@ TEST_CASE("Parse function type")
 
   REQUIRE(result->kind() == type::Kind::Function);
   function = As<type::Function>(result);
-  REQUIRE(function->parameters().size() == 1);
-  REQUIRE(function->return_type()->kind() == type::Kind::Named);
+  REQUIRE(function->parameters.size() == 1);
+  REQUIRE(function->return_type->kind() == type::Kind::Named);
 }
 
 TEST_CASE("Parse empty record type")
@@ -105,7 +105,7 @@ TEST_CASE("Parse empty record type")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Record);
-  REQUIRE(As<type::Record>(result)->fields().empty());
+  REQUIRE(As<type::Record>(result)->fields.empty());
 }
 
 TEST_CASE("Parse record type with one field")
@@ -114,7 +114,7 @@ TEST_CASE("Parse record type with one field")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Record);
-  REQUIRE(As<type::Record>(result)->fields().size() == 1);
+  REQUIRE(As<type::Record>(result)->fields.size() == 1);
 }
 
 TEST_CASE("Parse record type with one field and dangling comma")
@@ -123,7 +123,7 @@ TEST_CASE("Parse record type with one field and dangling comma")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Record);
-  REQUIRE(As<type::Record>(result)->fields().size() == 1);
+  REQUIRE(As<type::Record>(result)->fields.size() == 1);
 }
 
 TEST_CASE("Parse record type with string as field name")
@@ -132,7 +132,7 @@ TEST_CASE("Parse record type with string as field name")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Record);
-  REQUIRE(As<type::Record>(result)->fields().size() == 1);
+  REQUIRE(As<type::Record>(result)->fields.size() == 1);
 }
 
 TEST_CASE("Parse record type with two fields")
@@ -141,7 +141,7 @@ TEST_CASE("Parse record type with two fields")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::Record);
-  REQUIRE(As<type::Record>(result)->fields().size() == 2);
+  REQUIRE(As<type::Record>(result)->fields.size() == 2);
 }
 
 TEST_CASE("Parse unterminated record type")
@@ -159,8 +159,8 @@ TEST_CASE("Parse empty tuple type")
 
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
-  REQUIRE(multiple->multiple_kind() == type::Multiple::MultipleKind::Tuple);
-  REQUIRE(multiple->types().empty());
+  REQUIRE(multiple->multiple_kind == type::Multiple::MultipleKind::Tuple);
+  REQUIRE(multiple->types.empty());
 }
 
 TEST_CASE("Parse tuple type with one element")
@@ -171,8 +171,8 @@ TEST_CASE("Parse tuple type with one element")
 
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
-  REQUIRE(multiple->multiple_kind() == type::Multiple::MultipleKind::Tuple);
-  REQUIRE(multiple->types().size() == 1);
+  REQUIRE(multiple->multiple_kind == type::Multiple::MultipleKind::Tuple);
+  REQUIRE(multiple->types.size() == 1);
 }
 
 TEST_CASE("Parse tuple type with one element and dangling comma")
@@ -183,8 +183,8 @@ TEST_CASE("Parse tuple type with one element and dangling comma")
 
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
-  REQUIRE(multiple->multiple_kind() == type::Multiple::MultipleKind::Tuple);
-  REQUIRE(multiple->types().size() == 1);
+  REQUIRE(multiple->multiple_kind == type::Multiple::MultipleKind::Tuple);
+  REQUIRE(multiple->types.size() == 1);
 }
 
 TEST_CASE("Parse tuple type with two elements")
@@ -195,8 +195,8 @@ TEST_CASE("Parse tuple type with two elements")
 
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
-  REQUIRE(multiple->multiple_kind() == type::Multiple::MultipleKind::Tuple);
-  REQUIRE(multiple->types().size() == 2);
+  REQUIRE(multiple->multiple_kind == type::Multiple::MultipleKind::Tuple);
+  REQUIRE(multiple->types.size() == 2);
 }
 
 TEST_CASE("Parse unterminated tuple type")
@@ -234,7 +234,7 @@ TEST_CASE("Parse nested list type")
   const auto result = type::Parse(lexer);
 
   REQUIRE(result->kind() == type::Kind::List);
-  REQUIRE(As<type::List>(result)->element_type()->kind() == type::Kind::List);
+  REQUIRE(As<type::List>(result)->element_type->kind() == type::Kind::List);
 }
 
 TEST_CASE("Parse intersection type")
@@ -246,7 +246,7 @@ TEST_CASE("Parse intersection type")
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
   REQUIRE(
-    multiple->multiple_kind() == type::Multiple::MultipleKind::Intersection
+    multiple->multiple_kind == type::Multiple::MultipleKind::Intersection
   );
 }
 
@@ -258,5 +258,5 @@ TEST_CASE("Parse union type")
 
   REQUIRE(result->kind() == type::Kind::Multiple);
   multiple = As<type::Multiple>(result);
-  REQUIRE(multiple->multiple_kind() == type::Multiple::MultipleKind::Union);
+  REQUIRE(multiple->multiple_kind == type::Multiple::MultipleKind::Union);
 }


### PR DESCRIPTION
Since we are already working mostly with immutable data, having accessor methods makes very little sense. Getting rid of them also brings a signicant performance boost.