### PR TITLE
Add shorthand syntaxes for types, records and functions

### DIFF
--- a/examples/factorial.snek
+++ b/examples/factorial.snek
@@ -1,9 +1,11 @@
 #!/usr/bin/env snek
 
-const factorial = (n: Int) -> Int:
+const factorial(n: Int) -> Int:
     if n == 0:
         return 1
     else:
         return n * factorial(n - 1)
 
 print(factorial(4))
+
+# vim: set syntax=snek:

--- a/examples/fibonacci.snek
+++ b/examples/fibonacci.snek
@@ -1,9 +1,11 @@
 #!/usr/bin/env snek
 
-const fib = (n: Int) -> Int:
+const fib(n: Int) -> Int:
     if n < 2:
         return n
     else:
         return fib(n - 1) + fib(n - 2)
 
 print(fib(20))
+
+# vim: set syntax=snek:

--- a/examples/hello-world.snek
+++ b/examples/hello-world.snek
@@ -1,5 +1,9 @@
-export const hello = ():
+#!/usr/bin/env snek
+
+export const hello():
     print("Hello, World!")
 
 if __name__ == "__main__":
     hello()
+
+# vim: set syntax=snek:

--- a/examples/lo-dash.snek
+++ b/examples/lo-dash.snek
@@ -2,7 +2,7 @@
 
 # The opposite of before; this method creates a function that invokes func once
 # it's called n or more times.
-export const after = (n: Int, func: Function):
+export const after(n: Int, func: Function):
     let counter = 0
 
     return (...args):
@@ -12,7 +12,7 @@ export const after = (n: Int, func: Function):
 # Creates a function that invokes func while it's called less than n times.
 # Subsequent calls to the created function return the result of the last func
 # invocation.
-export const before = (n: Int, func: Function):
+export const before(n: Int, func: Function):
     let counter = 0
     let value
 
@@ -23,14 +23,14 @@ export const before = (n: Int, func: Function):
         return value
 
 # Creates function that invokes func with arguments reversed.
-export const flip = (func: Function) => (...args) => func(...args.reverse())
+export const flip(func: Function) => (...args) => func(...args.reverse())
 
 # Creates a function that negates the result of the predicate func.
-export const negate = (func: Function) => (...args) => !func(...args)
+export const negate(func: Function) => (...args) => !func(...args)
 
 # Creates a function that is restricted to invoking func once. Repeat calls to
 # the function return the value of the first invocation.
-export const once = (func: Function):
+export const once(func: Function):
     let called = false
     let value
 

--- a/examples/prototypes.snek
+++ b/examples/prototypes.snek
@@ -8,28 +8,27 @@ type Cat:
 
 # This will act as prototype for cats. These properties (or in this case
 # methods) will be inherited by all cats.
-const CatPrototype = {
+const CatPrototype:
     meow(this: Cat):
-        print("meow!"),
+        print("meow!")
 
     feed(this: Cat) => {
         ...this,
         mood: this.mood + 1,
         hungry: this.hungry - 1,
-    },
+    }
 
     play(this: Cat) => {
         ...this,
         mood: this.mood + 1,
         energy: this.energy - 1,
-    },
+    }
 
     sleep(this: Cat) => {
         ...this,
         hungry: this.hungry + 1,
         energy: this.energy + 1,
-    },
-}
+    }
 
 # This will build a new cat. A special property [[Prototype]] will define the
 # prototype used by the resulting cat.

--- a/examples/prototypes.snek
+++ b/examples/prototypes.snek
@@ -32,7 +32,7 @@ const CatPrototype:
 
 # This will build a new cat. A special property [[Prototype]] will define the
 # prototype used by the resulting cat.
-const newCat = () -> Cat => {
+const newCat() -> Cat => {
     "[[Prototype]]": CatPrototype,
     mood: 0,
     hungry: 0,

--- a/examples/prototypes.snek
+++ b/examples/prototypes.snek
@@ -1,11 +1,10 @@
 #!/usr/bin/env snek
 
 # This type definition will define what properties a cat has.
-type Cat = {
-    mood: Int,
-    hungry: Int,
-    energy: Int,
-}
+type Cat:
+    mood: Int
+    hungry: Int
+    energy: Int
 
 # This will act as prototype for cats. These properties (or in this case
 # methods) will be inherited by all cats.
@@ -42,3 +41,5 @@ const newCat = () -> Cat => {
 }
 
 newCat().feed().play().sleep().meow()
+
+# vim: set syntax=snek:

--- a/parser/include/snek/parser/expression.hpp
+++ b/parser/include/snek/parser/expression.hpp
@@ -104,6 +104,8 @@ namespace snek::parser::expression
 
   ptr ParseTernary(Lexer& lexer);
 
+  ptr ParseFunction(Lexer& lexer);
+
   class Assign final : public Base
   {
   public:

--- a/parser/include/snek/parser/lexer.hpp
+++ b/parser/include/snek/parser/lexer.hpp
@@ -131,6 +131,8 @@ namespace snek::parser
 
     std::u32string ReadString();
 
+    std::u32string ReadRecordKey();
+
   private:
     void LexLogicalLine();
 

--- a/parser/src/expression.cpp
+++ b/parser/src/expression.cpp
@@ -248,6 +248,16 @@ namespace snek::parser::expression
     ;
   }
 
+  ptr
+  ParseFunction(Lexer& lexer)
+  {
+    return ParseFunctionRest(
+      lexer.position(),
+      Parameter::ParseList(lexer, true),
+      lexer)
+    ;
+  }
+
   static ptr
   ParseParenthesized(const std::optional<Position>& position, Lexer& lexer)
   {

--- a/parser/src/lexer.cpp
+++ b/parser/src/lexer.cpp
@@ -391,6 +391,12 @@ namespace snek::parser
     return *token.text;
   }
 
+  std::u32string
+  Lexer::ReadRecordKey()
+  {
+    return PeekToken(Token::Kind::String) ? *ReadToken().text : ReadId();
+  }
+
   void
   Lexer::LexLogicalLine()
   {

--- a/parser/src/statement.cpp
+++ b/parser/src/statement.cpp
@@ -93,8 +93,19 @@ namespace snek::parser::statement
         token.position,
         *lexer.ReadToken().text
       );
+      // Shorthand function declaration.
+      if (lexer.PeekToken(Token::Kind::LeftParen))
+      {
+        return std::make_shared<DeclareVar>(
+          token.position,
+          exported,
+          token.kind == Token::Kind::KeywordConst,
+          variable,
+          expression::ParseFunction(lexer)
+        );
+      }
       // Record expression with block syntax.
-      if (lexer.PeekReadToken(Token::Kind::Colon))
+      else if (lexer.PeekReadToken(Token::Kind::Colon))
       {
         std::vector<field::ptr> fields;
 

--- a/parser/src/statement.cpp
+++ b/parser/src/statement.cpp
@@ -23,6 +23,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <functional>
+
 #include "snek/parser/error.hpp"
 #include "snek/parser/import.hpp"
 #include "snek/parser/statement.hpp"
@@ -38,6 +40,20 @@ namespace snek::parser::statement
     {
       lexer.PeekReadToken(Token::Kind::NewLine);
     }
+  }
+
+  static void
+  ParseBlockLike(Lexer& lexer, const std::function<void()>& callback)
+  {
+    lexer.ReadToken(Token::Kind::Indent);
+    do
+    {
+      if (!lexer.PeekReadToken(Token::Kind::NewLine))
+      {
+        callback();
+      }
+    }
+    while (!lexer.PeekReadToken(Token::Kind::Dedent));
   }
 
   static ptr
@@ -98,15 +114,31 @@ namespace snek::parser::statement
   {
     const auto position = lexer.ReadToken().position;
     const auto name = lexer.ReadId();
+    type::ptr type;
 
-    lexer.ReadToken(Token::Kind::Assign);
+    if (lexer.PeekReadToken(Token::Kind::Colon))
+    {
+      type::Record::container_type fields;
 
-    return std::make_shared<DeclareType>(
-      position,
-      exported,
-      name,
-      type::Parse(lexer)
-    );
+      // TODO: Support for single line type with ";".
+      lexer.ReadToken(Token::Kind::NewLine);
+      ParseBlockLike(
+        lexer,
+        [&]() -> void
+        {
+          const auto name = lexer.ReadRecordKey();
+
+          lexer.ReadToken(Token::Kind::Colon);
+          fields[name] = type::Parse(lexer);
+        }
+      );
+      type = std::make_shared<type::Record>(position, fields);
+    } else {
+      lexer.ReadToken(Token::Kind::Assign);
+      type = type::Parse(lexer);
+    }
+
+    return std::make_shared<DeclareType>(position, exported, name, type);
   }
 
   static ptr
@@ -226,15 +258,13 @@ namespace snek::parser::statement
       const auto position = lexer.position();
       statement::Block::container_type statements;
 
-      lexer.ReadToken(Token::Kind::Indent);
-      do
-      {
-        if (!lexer.PeekReadToken(Token::Kind::NewLine))
+      ParseBlockLike(
+        lexer,
+        [&]() -> void
         {
           statements.push_back(Parse(lexer, false));
         }
-      }
-      while (!lexer.PeekReadToken(Token::Kind::Dedent));
+      );
 
       return std::make_shared<Block>(position, statements);
     }

--- a/parser/src/statement.cpp
+++ b/parser/src/statement.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 
 #include "snek/parser/error.hpp"
+#include "snek/parser/field.hpp"
 #include "snek/parser/import.hpp"
 #include "snek/parser/statement.hpp"
 #include "snek/parser/type.hpp"
@@ -83,17 +84,49 @@ namespace snek::parser::statement
   ParseDeclareVar(Lexer& lexer, bool exported = false)
   {
     const auto token = lexer.ReadToken();
-    const auto variable = expression::ParseTernary(lexer);
+    expression::ptr variable;
     expression::ptr value;
 
-    if (!variable->IsAssignable())
+    if (lexer.PeekToken(Token::Kind::Id))
     {
-      throw SyntaxError{
-        variable->position,
-        U"Cannot assign to " +
-        variable->ToString() +
-        U"."
-      };
+      variable = std::make_shared<expression::Id>(
+        token.position,
+        *lexer.ReadToken().text
+      );
+      // Record expression with block syntax.
+      if (lexer.PeekReadToken(Token::Kind::Colon))
+      {
+        std::vector<field::ptr> fields;
+
+        // TODO: Support for single line record with ";".
+        lexer.ReadToken(Token::Kind::NewLine);
+        ParseBlockLike(
+          lexer,
+          [&]() -> void
+          {
+            fields.push_back(field::Parse(lexer));
+          }
+        );
+
+        return std::make_shared<DeclareVar>(
+          token.position,
+          exported,
+          token.kind == Token::Kind::KeywordConst,
+          variable,
+          std::make_shared<expression::Record>(variable->position, fields)
+        );
+      }
+    } else {
+      variable = expression::ParseTernary(lexer);
+      if (!variable->IsAssignable())
+      {
+        throw SyntaxError{
+          variable->position,
+          U"Cannot assign to " +
+          variable->ToString() +
+          U"."
+        };
+      }
     }
     if (lexer.PeekReadToken(Token::Kind::Assign))
     {

--- a/parser/src/type.cpp
+++ b/parser/src/type.cpp
@@ -126,9 +126,7 @@ namespace snek::parser::type
       lexer,
       [&]() -> void
       {
-        const auto name = lexer.PeekToken(Token::Kind::String)
-          ? *lexer.ReadToken().text
-          : lexer.ReadId();
+        const auto name = lexer.ReadRecordKey();
 
         lexer.ReadToken(Token::Kind::Colon);
         fields[name] = Parse(lexer);


### PR DESCRIPTION
Introduce shorthand syntaxes for declaring types, records and functions like this:

```
type MyType:
    foo: String

const MyRecord:
    foo: "bar"

const function(a: Int, b: Int) -> Int:
    return a + b
```

Which are equivalent of these:

```
type MyType = {
    foo: String,
}

const MyRecord = {
    foo: "bar",
}

const function = (a: Int, b: Int) -> Int:
    return a + b
```